### PR TITLE
fix: prettier 잘못된 파일명 수정

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -9,6 +9,6 @@ module.exports = {
   semi: false,
   arrowParens: 'always',
   plugins: [require.resolve('prettier-plugin-tailwindcss')],
-  tailwindConfig: './tailwind.config.js',
+  tailwindConfig: './tailwind.config.ts',
   tailwindFunctions: ['clsx', 'tw'],
 }


### PR DESCRIPTION
## 작업 내용

> 사진, 코드 등 리뷰어가 쉽게 이해할수 있게 상세히 리뷰어에 입장에서 작성해주요.
> 

prettier 설정 파일에 tailwind 파일 확장자 수정

## 이러한 변경이 이루어지는 이유는 무엇인가요?

prettier 설정 파일에 tailwind 파일 확장가 틀려서 에러가 발생하여  

## 테스트 방법

> 변경사항에 대해 리뷰어가 테스트할 수 있는 가이드를 step by step으로 제공하세요.
> 
1.  prettier 동작 확인

안 되면
1. `yarn install`
2. `yarn dlx @yarnpkg/sdks vscode`
3. 에디터 껐다 키기

## 병합 전 체크리스트

- [ ]  수정 내용에 오타나 컨벤션이 틀린 부분이 없는지 확인했나요?
- [ ]  추가된 리뷰에 대해 모두 수정 및 재리뷰를 완료했나요?
