### PR TITLE
prettier개선

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,8 @@
   "editor.formatOnSave": true,
   "editor.formatOnSaveMode": "file",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "explicit"
+    "source.fixAll.eslint": "explicit",
+    "source.organizeImports": "explicit"
   },
   "prettier.requireConfig": true,
   "prettier.prettierPath": ".yarn/sdks/prettier/index.cjs"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
+  "editor.formatOnSaveMode": "file",
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
   },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,6 +20,8 @@ export default [
       '@next/next': nextPlugin,
     },
     rules: {
+      '@typescript-eslint/no-unused-vars': 'warn',
+      '@typescript-eslint/no-explicit-any': 'warn',
       'prettier/prettier': 'error',
       'tailwindcss/no-custom-classname': 'off',
       'tailwindcss/classnames-order': 'off',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": [".yarn", ".next"]
 }


### PR DESCRIPTION
## 작업 내용

> 사진, 코드 등 리뷰어가 쉽게 이해할수 있게 상세히 리뷰어에 입장에서 작성해주요.
> 

### prettier 저장이 느려지는 현상 수정
<img width="753" alt="KakaoTalk_Photo_2025-01-05-11-37-54" src="https://github.com/user-attachments/assets/690230fb-0007-498b-bc26-20208318ad28" />

- 저장시 포멧팅 모드 옵션을 "file"로 설정하는 옵션을 워크스페이스의 settings.json에 추가
- typescript 컴파일 범위에서 .yran폴더와 .next폴더 제외
- [참고 이슈](https://github.com/prettier/prettier-vscode/issues/1333)

### prettier 규칙 변경
- 변수 미사용, any 타입 사용 규칙을 error단계에서 warn단계로 완화
```js
    rules: {
      '@typescript-eslint/no-unused-vars': 'warn',
      '@typescript-eslint/no-explicit-any': 'warn',
       ...
     }
```

### 워크스페이스 settings.json에 import 옵션 추가
- 저장시 import 최적화하는 옵션을 워크스페이스의 settings.json에 추가
https://github.com/user-attachments/assets/e0fc6f82-3d7d-4205-9621-a89a9fe54900


## 이러한 변경이 이루어지는 이유는 무엇인가요?

- 에디터 저장이 느려지는 현상을 수정하기 위해
- 규칙완화로 사용자에 판단하에 허용하기 위해
- 불필요한 import를 제거하여 컴파일 속도 향상을 위해

## 테스트 방법

> 변경사항에 대해 리뷰어가 테스트할 수 있는 가이드를 step by step으로 제공하세요.
> 
1. 파일 변경 후 저장을 한다.
2. 딜레이 없이 저장되는 지 확인한다.
3. 사용하지 않는 import를 만든다.
4. 저장 후 사용되지 않는 import가 제거되는 지 확인한다.

## 병합 전 체크리스트

- [ ]  수정 내용에 오타나 컨벤션이 틀린 부분이 없는지 확인했나요?
- [ ]  추가된 리뷰에 대해 모두 수정 및 재리뷰를 완료했나요?
