### PR TITLE
Fix : 주문 내역 페이지 피그마대로 구현

### DIFF
--- a/src/app/orders/_components/Order.tsx
+++ b/src/app/orders/_components/Order.tsx
@@ -9,15 +9,15 @@ const Order = () => {
         <div className="px-mobile_safe">
           <OrderSearch />
         </div>
-        <div className="flex flex-1 flex-col gap-10 overflow-y-auto px-mobile_safe">
+        <div className="flex flex-1 flex-col gap-10 overflow-y-auto px-mobile_safe mb-10">
           <OrderItem />
-          <Separator ignoreMobileSafe />
+          <Separator ignoreMobileSafe className="h-2"/>
           <OrderItem />
-          <Separator ignoreMobileSafe />
+          <Separator ignoreMobileSafe className="h-2"/>
           <OrderItem />
-          <Separator ignoreMobileSafe />
+          <Separator ignoreMobileSafe className="h-2"/>
           <OrderItem />
-          <Separator ignoreMobileSafe />
+          <Separator ignoreMobileSafe className="h-2"/>
           <OrderItem />
         </div>
       </div>

--- a/src/app/orders/_components/Order.tsx
+++ b/src/app/orders/_components/Order.tsx
@@ -1,23 +1,23 @@
 import OrderSearch from '@/app/orders/_components/OrderSearch'
 import OrderItem from '@/app/orders/_components/OrderItem'
-import { Separator } from '@/components/shadcn/separator'
+import Separator from '@/components/Separator'
 
 const Order = () => {
   return (
     <>
-      <div className="flex h-full flex-col gap-7">
-        <div className="h-navigation px-mobile_safe pt-2">
+      <div className="flex flex-col gap-10 pt-5">
+        <div className="px-mobile_safe">
           <OrderSearch />
         </div>
-        <div className="flex flex-1 flex-col gap-5 overflow-y-auto p-3 px-mobile_safe">
+        <div className="flex flex-1 flex-col gap-10 overflow-y-auto px-mobile_safe">
           <OrderItem />
-          <Separator />
+          <Separator ignoreMobileSafe />
           <OrderItem />
-          <Separator />
+          <Separator ignoreMobileSafe />
           <OrderItem />
-          <Separator />
+          <Separator ignoreMobileSafe />
           <OrderItem />
-          <Separator />
+          <Separator ignoreMobileSafe />
           <OrderItem />
         </div>
       </div>

--- a/src/app/orders/_components/Order.tsx
+++ b/src/app/orders/_components/Order.tsx
@@ -1,18 +1,23 @@
 import OrderSearch from '@/app/orders/_components/OrderSearch'
 import OrderItem from '@/app/orders/_components/OrderItem'
+import { Separator } from '@/components/shadcn/separator'
 
 const Order = () => {
   return (
     <>
-      <div className="flex h-full flex-col gap-5">
+      <div className="flex h-full flex-col gap-7">
         <div className="h-navigation px-mobile_safe pt-2">
           <OrderSearch />
         </div>
-        <div className="flex flex-1 flex-col gap-4 overflow-y-auto p-3 px-mobile_safe">
+        <div className="flex flex-1 flex-col gap-5 overflow-y-auto p-3 px-mobile_safe">
           <OrderItem />
+          <Separator />
           <OrderItem />
+          <Separator />
           <OrderItem />
+          <Separator />
           <OrderItem />
+          <Separator />
           <OrderItem />
         </div>
       </div>

--- a/src/app/orders/_components/OrderItem.tsx
+++ b/src/app/orders/_components/OrderItem.tsx
@@ -5,31 +5,31 @@ import Badge from '@/components/Badge'
 
 const OrderItem = () => {
   return (
-    <div className="flex flex-col gap-3">
-      <div className="flex flex-row items-center">
+    <div className="flex flex-col gap-5">
+      <div className="flex flex-row">
         <Image
-          className="size-[85px] rounded-xl object-cover object-center"
+          className="size-[100px] rounded-xl object-cover object-center"
           src={
             'https://flexible.img.hani.co.kr/flexible/normal/970/647/imgdb/resize/2017/0709/149948783091_20170709.JPG'
           }
           alt="음식점 대표 이미지"
-          width={85}
-          height={85}
+          width={100}
+          height={100}
           loading="lazy"
         />
-        <div className="flex w-4/5 flex-col gap-2 pl-3">
+        <div className="flex w-[calc(100%-1rem-100px)] flex-col gap-4 pl-4">
           <div className="flex flex-row justify-between">
             <Badge variant="complete">배달완료</Badge>
-            <div className="text-xs text-gray-400">2025.01.11 오후 07:24</div>
+            <div className="place-content-center text-xs text-gray-400">2025.01.11 오후 07:24</div>
           </div>
-          <div className="flex flex-col gap-1">
+          <div className="flex flex-col gap-2">
             <div className="truncate text-lg font-bold hover:text-clip">빙동댕</div>
             <div className="text-sm text-gray-700">새우 로제 파스타 외 2개 20,000원</div>
           </div>
         </div>
       </div>
       <div className="flex flex-row justify-center gap-7">
-        <Button variant="primaryFit" size="s" className="w-1/2">
+        <Button size="s" className="w-1/2">
           주문 상세
         </Button>
         <Button variant="grayFit" size="s" className="w-1/2">

--- a/src/app/orders/_components/OrderItem.tsx
+++ b/src/app/orders/_components/OrderItem.tsx
@@ -28,11 +28,11 @@ const OrderItem = () => {
           </div>
         </div>
       </div>
-      <div className="flex flex-row justify-center gap-7">
-        <Button size="s" className="w-1/2">
+      <div className="flex flex-row justify-center gap-3">
+        <Button size="s" className="w-1/2 h-10">
           주문 상세
         </Button>
-        <Button variant="grayFit" size="s" className="w-1/2">
+        <Button variant="grayFit" size="s" className="w-1/2 h-10">
           리뷰 달기
         </Button>
       </div>

--- a/src/app/orders/_components/OrderItem.tsx
+++ b/src/app/orders/_components/OrderItem.tsx
@@ -1,29 +1,36 @@
 import Chip from '@/components/Chip'
 import Image from 'next/image'
 import { Button } from '@/components/button'
+import Badge from '@/components/Badge'
 
 const OrderItem = () => {
   return (
-    <div className="flex flex-col gap-3 border border-solid border-gray-400 p-3 px-mobile_safe rounded">
+    <div className="flex flex-col gap-3">
       <div className="flex flex-row items-center">
         <Image
-          className="size-[70px] rounded-xl object-cover object-center"
+          className="size-[85px] rounded-xl object-cover object-center"
           src={
             'https://flexible.img.hani.co.kr/flexible/normal/970/647/imgdb/resize/2017/0709/149948783091_20170709.JPG'
           }
           alt="음식점 대표 이미지"
-          width={70}
-          height={70}
+          width={85}
+          height={85}
           loading="lazy"
         />
-        <div className="flex flex-col gap-2 pl-3">
-          <div className="text-lg font-bold">빙동댕 {'>'}</div>
-          <div className="text-sm text-gray-700">새우 로제 파스타 외 2개 20,000원</div>
+        <div className="flex w-4/5 flex-col gap-2 pl-3">
+          <div className="flex flex-row justify-between">
+            <Badge variant="complete">배달완료</Badge>
+            <div className="text-xs text-gray-400">2025.01.11 오후 07:24</div>
+          </div>
+          <div className="flex flex-col gap-1">
+            <div className="truncate text-lg font-bold hover:text-clip">빙동댕</div>
+            <div className="text-sm text-gray-700">새우 로제 파스타 외 2개 20,000원</div>
+          </div>
         </div>
       </div>
       <div className="flex flex-row justify-center gap-7">
         <Button variant="primaryFit" size="s" className="w-1/2">
-          같은 메뉴 담기
+          주문 상세
         </Button>
         <Button variant="grayFit" size="s" className="w-1/2">
           리뷰 달기

--- a/src/app/orders/_components/OrderSearch.tsx
+++ b/src/app/orders/_components/OrderSearch.tsx
@@ -1,15 +1,22 @@
+'use client'
+
 import Input from '@/components/input'
 import Icon from '@/components/Icon'
-import { COLORS } from '@/styles/color'
+import { useState } from 'react'
 
 const OrderSearch = () => {
+  const [word, setWord] = useState('')
+
   return (
     <div className="mb-6 flex w-full flex-col gap-7">
       <div className="w-full bg-white">
         <Input
-          type="search"
           placeholder="주문 내역을 검색하세요"
-          icon={<Icon name="Search" size={20} color={COLORS.gray400} />}
+          value={word}
+          onChange={(e) => setWord(e.target.value)}
+          onReset={() => setWord('')}
+          icon={<Icon name="Search" size={18} />}
+          offOutline
         />
       </div>
     </div>

--- a/src/app/orders/_components/OrderSearch.tsx
+++ b/src/app/orders/_components/OrderSearch.tsx
@@ -8,7 +8,7 @@ const OrderSearch = () => {
   const [word, setWord] = useState('')
 
   return (
-    <div className="mb-6 flex w-full flex-col gap-7">
+    <div className="flex w-full flex-col gap-7">
       <div className="w-full bg-white">
         <Input
           placeholder="주문 내역을 검색하세요"

--- a/src/app/orders/_components/OrderSearch.tsx
+++ b/src/app/orders/_components/OrderSearch.tsx
@@ -13,6 +13,7 @@ const OrderSearch = () => {
         <Input
           placeholder="주문 내역을 검색하세요"
           value={word}
+          inputSize="sm"
           onChange={(e) => setWord(e.target.value)}
           onReset={() => setWord('')}
           icon={<Icon name="Search" size={18} />}

--- a/src/components/shadcn/separator.tsx
+++ b/src/components/shadcn/separator.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import * as React from 'react'
+import * as SeparatorPrimitive from '@radix-ui/react-separator'
+
+import { cn } from '@/lib/utils'
+
+const Separator = React.forwardRef<
+  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(({ className, orientation = 'horizontal', decorative = true, ...props }, ref) => (
+  <SeparatorPrimitive.Root
+    ref={ref}
+    decorative={decorative}
+    orientation={orientation}
+    className={cn(
+      'shrink-0 bg-border',
+      orientation === 'horizontal' ? 'h-[1px] w-full' : 'h-full w-[1px]',
+      className,
+    )}
+    {...props}
+  />
+))
+Separator.displayName = SeparatorPrimitive.Root.displayName
+
+export { Separator }


### PR DESCRIPTION
## 작업 내용

> 사진, 코드 등 리뷰어가 쉽게 이해할수 있게 상세히 리뷰어에 입장에서 작성해주요.
> 

![image](https://github.com/user-attachments/assets/9d9ceb59-cc7f-499a-aa9a-f951020598f8)


## 이러한 변경이 이루어지는 이유는 무엇인가요?

피그마대로 화면을 수정하였습니다.
깨진 css를 바로 잡고 공통 seperator를 적용했습니다.

## 테스트 방법

> 변경사항에 대해 리뷰어가 테스트할 수 있는 가이드를 step by step으로 제공하세요.
> 
1. 화면 전반적으로 봐주시면 감사하겠습니다.

## 병합 전 체크리스트

- [ ]  수정 내용에 오타나 컨벤션이 틀린 부분이 없는지 확인했나요?
- [ ]  추가된 리뷰에 대해 모두 수정 및 재리뷰를 완료했나요?
