### PR TITLE
feat: 작성전 리뷰 페이지 퍼블리싱

### DIFF
--- a/src/app/review/_components/CompletedReviews.tsx
+++ b/src/app/review/_components/CompletedReviews.tsx
@@ -1,0 +1,5 @@
+const CompletedReviews = () => {
+  return <section>CompletedReviews</section>
+}
+
+export default CompletedReviews

--- a/src/app/review/_components/NoPendingReview.tsx
+++ b/src/app/review/_components/NoPendingReview.tsx
@@ -1,0 +1,10 @@
+import Icon from '@/components/Icon'
+
+const NoPendingReview = () => (
+  <div className="flex h-[calc(100vh-190px)] flex-col items-center justify-center gap-6">
+    <Icon name="UtensilsCrossed" size="96px" className="text-gray-400" />
+    <div className="font-medium text-gray-400">주문 후 리뷰를 작성해주세요!</div>
+  </div>
+)
+
+export default NoPendingReview

--- a/src/app/review/_components/PedingReviewSkeleton.tsx
+++ b/src/app/review/_components/PedingReviewSkeleton.tsx
@@ -1,0 +1,26 @@
+import { Button } from '@/components/button'
+import { Separator } from '@/components/shadcn/separator'
+
+const PedingReviewSkeleton = ({ offSeparator = false }: { offSeparator: boolean }) => {
+  return (
+    <>
+      <div className="flex animate-pulse-custom gap-4 px-mobile_safe py-5">
+        <div className="size-[76px] animate-pulse-custom rounded-sm bg-gray-300" />
+        <div className="flex flex-col justify-between gap-2 text-sm">
+          <div>
+            <div className="mb-1 h-4 w-[130px] animate-pulse-custom rounded-sm bg-gray-300" />
+            <ul className="whitespace-pre-wrap">
+              <li className="h-4 w-[180px] animate-pulse-custom rounded-sm bg-gray-300" />
+            </ul>
+          </div>
+          <Button variant="primaryFit" size="s" className="h-fit py-0.5">
+            리뷰 작성
+          </Button>
+        </div>
+      </div>
+      {!offSeparator && <Separator className="h-2" />}
+    </>
+  )
+}
+
+export default PedingReviewSkeleton

--- a/src/app/review/_components/PendingReview.tsx
+++ b/src/app/review/_components/PendingReview.tsx
@@ -1,0 +1,43 @@
+import { Button } from '@/components/button'
+import Separator from '@/components/Separator'
+import { type PendingReview } from '@/models/review'
+import Image from 'next/image'
+
+interface PendingReviewProps {
+  review: PendingReview
+  offSeparator?: boolean
+}
+
+const PendingReview = ({ review, offSeparator = false }: PendingReviewProps) => {
+  return (
+    <>
+      <div className="flex gap-4 px-mobile_safe py-5">
+        <Image
+          src={review.storeImageUrl}
+          alt="pending-review"
+          width={76}
+          height={76}
+          className="mt-1 size-[76px] rounded-sm bg-gray-300"
+        />
+        <div className="flex flex-col justify-between gap-2 text-sm">
+          <div>
+            <div className="font-semibold">{review.storeName}</div>
+            <ul className="whitespace-pre-wrap">
+              {review.menus.map((menu) => (
+                <li key={menu.menuName}>
+                  {menu.menuName} x {menu.menuCount}
+                </li>
+              ))}
+            </ul>
+          </div>
+          <Button variant="primaryFit" size="s" className="h-fit py-0.5">
+            리뷰 작성
+          </Button>
+        </div>
+      </div>
+      {!offSeparator && <Separator ignoreMobileSafe className="h-2" />}
+    </>
+  )
+}
+
+export default PendingReview

--- a/src/app/review/_components/PendingReviews.tsx
+++ b/src/app/review/_components/PendingReviews.tsx
@@ -1,0 +1,5 @@
+const PendingReviews = () => {
+  return <section>PendingReviews</section>
+}
+
+export default PendingReviews

--- a/src/app/review/_components/PendingReviews.tsx
+++ b/src/app/review/_components/PendingReviews.tsx
@@ -1,5 +1,0 @@
-const PendingReviews = () => {
-  return <section>PendingReviews</section>
-}
-
-export default PendingReviews

--- a/src/app/review/_components/Review.tsx
+++ b/src/app/review/_components/Review.tsx
@@ -3,6 +3,7 @@
 import CompletedReviews from '@/app/review/_components/CompletedReviews'
 import PendingReview from '@/app/review/_components/PendingReview'
 import ReviewTab from '@/app/review/_components/ReviewTab'
+import Icon from '@/components/Icon'
 import { usePendingReviews } from '@/models/review'
 import { motion } from 'motion/react'
 import { useState } from 'react'
@@ -35,13 +36,20 @@ const Review = () => {
           transition={{ duration: 0.3 }}
           className="absolute w-full"
         >
-          {pendingReviews?.map((review, index) => (
-            <PendingReview
-              key={review.orderId}
-              review={review}
-              offSeparator={index === pendingReviews.length - 1}
-            />
-          ))}
+          {pendingReviews ? (
+            pendingReviews.map((review, index) => (
+              <PendingReview
+                key={review.orderId}
+                review={review}
+                offSeparator={index === pendingReviews.length - 1}
+              />
+            ))
+          ) : (
+            <div className="flex h-[calc(100vh-190px)] flex-col items-center justify-center gap-6">
+              <Icon name="UtensilsCrossed" size="96px" className="text-gray-400" />
+              <div className="font-medium text-gray-400">주문 후 리뷰를 작성해주세요!</div>
+            </div>
+          )}
         </motion.div>
 
         <motion.div

--- a/src/app/review/_components/Review.tsx
+++ b/src/app/review/_components/Review.tsx
@@ -16,13 +16,15 @@ const Review = () => {
   }
 
   return (
-    <section className="px-mobile_safe">
-      <ReviewTab tab={tab} onChangeTab={handleChangeTab} />
+    <section>
+      <div className="px-mobile_safe">
+        <ReviewTab tab={tab} onChangeTab={handleChangeTab} />
+      </div>
       <div className="relative h-screen overflow-hidden">
         <motion.div
           initial={{ x: 0 }}
           animate={{
-            x: tab === '작성가능' ? 0 : '-100%',
+            x: tab === '작성가능' ? 0 : '-110%',
           }}
           transition={{ duration: 0.3 }}
           className="absolute w-full"
@@ -31,9 +33,9 @@ const Review = () => {
         </motion.div>
 
         <motion.div
-          initial={{ x: '100%' }}
+          initial={{ x: '110%' }}
           animate={{
-            x: tab === '작성가능' ? '100%' : 0,
+            x: tab === '작성가능' ? '110%' : 0,
           }}
           transition={{ duration: 0.3 }}
           className="absolute w-full"

--- a/src/app/review/_components/Review.tsx
+++ b/src/app/review/_components/Review.tsx
@@ -26,7 +26,7 @@ const Review = () => {
           pendingReviewsCount={pendingReviews?.length ?? 0}
         />
       </div>
-      <div className="relative mt-2 h-[calc(100vh-180px)] overflow-y-auto overflow-x-hidden">
+      <div className="relative mt-2 h-[calc(100vh-190px)] overflow-y-auto overflow-x-hidden">
         <motion.div
           initial={{ x: 0 }}
           animate={{

--- a/src/app/review/_components/Review.tsx
+++ b/src/app/review/_components/Review.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import ReviewTab from '@/app/review/_components/ReviewTab'
+import { useState } from 'react'
+
+export type ReviewTabType = '작성가능' | '작성완료'
+
+const Review = () => {
+  const [tab, setTab] = useState<ReviewTabType>('작성가능')
+
+  const handleChangeTab = (tab: ReviewTabType) => {
+    setTab(tab)
+  }
+
+  return (
+    <section className="px-mobile_safe">
+      <ReviewTab tab={tab} onChangeTab={handleChangeTab} />
+    </section>
+  )
+}
+
+export default Review

--- a/src/app/review/_components/Review.tsx
+++ b/src/app/review/_components/Review.tsx
@@ -1,6 +1,9 @@
 'use client'
 
+import CompletedReviews from '@/app/review/_components/CompletedReviews'
+import PendingReviews from '@/app/review/_components/PendingReviews'
 import ReviewTab from '@/app/review/_components/ReviewTab'
+import { motion } from 'motion/react'
 import { useState } from 'react'
 
 export type ReviewTabType = '작성가능' | '작성완료'
@@ -15,6 +18,29 @@ const Review = () => {
   return (
     <section className="px-mobile_safe">
       <ReviewTab tab={tab} onChangeTab={handleChangeTab} />
+      <div className="relative h-screen overflow-hidden">
+        <motion.div
+          initial={{ x: 0 }}
+          animate={{
+            x: tab === '작성가능' ? 0 : '-100%',
+          }}
+          transition={{ duration: 0.3 }}
+          className="absolute w-full"
+        >
+          <PendingReviews />
+        </motion.div>
+
+        <motion.div
+          initial={{ x: '100%' }}
+          animate={{
+            x: tab === '작성가능' ? '100%' : 0,
+          }}
+          transition={{ duration: 0.3 }}
+          className="absolute w-full"
+        >
+          <CompletedReviews />
+        </motion.div>
+      </div>
     </section>
   )
 }

--- a/src/app/review/_components/Review.tsx
+++ b/src/app/review/_components/Review.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import CompletedReviews from '@/app/review/_components/CompletedReviews'
+import PedingReviewSkeleton from '@/app/review/_components/PedingReviewSkeleton'
 import PendingReview from '@/app/review/_components/PendingReview'
 import ReviewTab from '@/app/review/_components/ReviewTab'
 import Icon from '@/components/Icon'
@@ -12,7 +13,7 @@ export type ReviewTabType = '작성가능' | '작성완료'
 
 const Review = () => {
   const [tab, setTab] = useState<ReviewTabType>('작성가능')
-  const { data: pendingReviews } = usePendingReviews()
+  const { data: pendingReviews, isLoading } = usePendingReviews()
 
   const handleChangeTab = (tab: ReviewTabType) => {
     setTab(tab)
@@ -36,7 +37,11 @@ const Review = () => {
           transition={{ duration: 0.3 }}
           className="absolute w-full"
         >
-          {pendingReviews ? (
+          {isLoading ? (
+            Array.from({ length: 5 }).map((_, i) => (
+              <PedingReviewSkeleton key={i} offSeparator={i === 4} />
+            ))
+          ) : pendingReviews ? (
             pendingReviews.map((review, index) => (
               <PendingReview
                 key={review.orderId}

--- a/src/app/review/_components/Review.tsx
+++ b/src/app/review/_components/Review.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import CompletedReviews from '@/app/review/_components/CompletedReviews'
+import NoPendingReview from '@/app/review/_components/NoPendingReview'
 import PedingReviewSkeleton from '@/app/review/_components/PedingReviewSkeleton'
 import PendingReview from '@/app/review/_components/PendingReview'
 import ReviewTab from '@/app/review/_components/ReviewTab'
-import Icon from '@/components/Icon'
 import { usePendingReviews } from '@/models/review'
 import { motion } from 'motion/react'
 import { useState } from 'react'
@@ -50,10 +50,7 @@ const Review = () => {
               />
             ))
           ) : (
-            <div className="flex h-[calc(100vh-190px)] flex-col items-center justify-center gap-6">
-              <Icon name="UtensilsCrossed" size="96px" className="text-gray-400" />
-              <div className="font-medium text-gray-400">주문 후 리뷰를 작성해주세요!</div>
-            </div>
+                <NoPendingReview />
           )}
         </motion.div>
 

--- a/src/app/review/_components/Review.tsx
+++ b/src/app/review/_components/Review.tsx
@@ -1,8 +1,9 @@
 'use client'
 
 import CompletedReviews from '@/app/review/_components/CompletedReviews'
-import PendingReviews from '@/app/review/_components/PendingReviews'
+import PendingReview from '@/app/review/_components/PendingReview'
 import ReviewTab from '@/app/review/_components/ReviewTab'
+import { usePendingReviews } from '@/models/review'
 import { motion } from 'motion/react'
 import { useState } from 'react'
 
@@ -10,6 +11,7 @@ export type ReviewTabType = '작성가능' | '작성완료'
 
 const Review = () => {
   const [tab, setTab] = useState<ReviewTabType>('작성가능')
+  const { data: pendingReviews } = usePendingReviews()
 
   const handleChangeTab = (tab: ReviewTabType) => {
     setTab(tab)
@@ -18,9 +20,13 @@ const Review = () => {
   return (
     <section>
       <div className="px-mobile_safe">
-        <ReviewTab tab={tab} onChangeTab={handleChangeTab} />
+        <ReviewTab
+          tab={tab}
+          onChangeTab={handleChangeTab}
+          pendingReviewsCount={pendingReviews?.length ?? 0}
+        />
       </div>
-      <div className="relative h-screen overflow-hidden">
+      <div className="relative mt-2 h-[calc(100vh-180px)] overflow-y-auto overflow-x-hidden">
         <motion.div
           initial={{ x: 0 }}
           animate={{
@@ -29,7 +35,13 @@ const Review = () => {
           transition={{ duration: 0.3 }}
           className="absolute w-full"
         >
-          <PendingReviews />
+          {pendingReviews?.map((review, index) => (
+            <PendingReview
+              key={review.orderId}
+              review={review}
+              offSeparator={index === pendingReviews.length - 1}
+            />
+          ))}
         </motion.div>
 
         <motion.div

--- a/src/app/review/_components/ReviewTab.tsx
+++ b/src/app/review/_components/ReviewTab.tsx
@@ -1,0 +1,45 @@
+import { ReviewTabType } from '@/app/review/_components/Review'
+import { motion } from 'motion/react'
+
+interface ReviewTabProps {
+  tab: ReviewTabType
+  onChangeTab: (tab: ReviewTabType) => void
+}
+
+const ReviewTab = ({ tab, onChangeTab }: ReviewTabProps) => {
+  const handleClickTab = (e: React.MouseEvent<HTMLButtonElement>) => {
+    onChangeTab(e.currentTarget.value as ReviewTabType)
+  }
+
+  return (
+    <div className="relative flex h-10 justify-center rounded-sm bg-primary/15 text-sm font-medium">
+      <button
+        onClick={handleClickTab}
+        value="작성가능"
+        className={`w-1/2 ${tab === '작성가능' ? 'text-white' : 'text-gray-700'}`}
+      >
+        {`작성 가능한 리뷰 (${2})`}
+      </button>
+      <button
+        onClick={handleClickTab}
+        value="작성완료"
+        className={`w-1/2 ${tab === '작성완료' ? 'text-white' : 'text-gray-700'}`}
+      >
+        {`작성한 리뷰 (${2})`}
+      </button>
+      <motion.div
+        className="absolute left-1 top-1 -z-10 h-[32px] w-[calc(50%-4px)] rounded-sm bg-primary"
+        animate={{
+          x: tab === '작성가능' ? '0%' : '100%',
+        }}
+        transition={{
+          type: 'spring',
+          stiffness: 200,
+          damping: 40,
+        }}
+      />
+    </div>
+  )
+}
+
+export default ReviewTab

--- a/src/app/review/_components/ReviewTab.tsx
+++ b/src/app/review/_components/ReviewTab.tsx
@@ -4,9 +4,10 @@ import { motion } from 'motion/react'
 interface ReviewTabProps {
   tab: ReviewTabType
   onChangeTab: (tab: ReviewTabType) => void
+  pendingReviewsCount: number
 }
 
-const ReviewTab = ({ tab, onChangeTab }: ReviewTabProps) => {
+const ReviewTab = ({ tab, onChangeTab, pendingReviewsCount }: ReviewTabProps) => {
   const handleClickTab = (e: React.MouseEvent<HTMLButtonElement>) => {
     onChangeTab(e.currentTarget.value as ReviewTabType)
   }
@@ -18,7 +19,7 @@ const ReviewTab = ({ tab, onChangeTab }: ReviewTabProps) => {
         value="작성가능"
         className={`w-1/2 ${tab === '작성가능' ? 'text-white' : 'text-gray-700'}`}
       >
-        {`작성 가능한 리뷰 (${2})`}
+        {`작성 가능한 리뷰 (${pendingReviewsCount})`}
       </button>
       <button
         onClick={handleClickTab}

--- a/src/app/review/layout.tsx
+++ b/src/app/review/layout.tsx
@@ -1,0 +1,10 @@
+import MainLayout from '@/components/MainLayout'
+import { ReactNode } from 'react'
+
+interface MypageLayoutProps {
+  children: ReactNode
+}
+
+export default function MypageLayout({ children }: MypageLayoutProps) {
+  return <MainLayout>{children}</MainLayout>
+}

--- a/src/app/review/page.tsx
+++ b/src/app/review/page.tsx
@@ -1,0 +1,7 @@
+import Review from './_components/Review'
+
+const ReviewPage = () => {
+  return <Review />
+}
+
+export default ReviewPage

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -29,7 +29,8 @@ import {
   Store,
   TriangleAlert,
   User,
-  X
+  UtensilsCrossed,
+  X,
 } from 'lucide-react'
 import { HTMLAttributes } from 'react'
 
@@ -64,7 +65,8 @@ const ICONS = {
   Link,
   Bike,
   MapPin,
-  Plus
+  Plus,
+  UtensilsCrossed,
 } as const
 
 export type IconName = keyof typeof ICONS // 아이콘 목록

--- a/src/constants/navigationProps.tsx
+++ b/src/constants/navigationProps.tsx
@@ -51,6 +51,10 @@ const NAVIGATION_PROPS: Record<string, NavigationProps> = {
   [ROUTE_PATHS.PAY]: {
     title: '주문하기',
   },
+  [ROUTE_PATHS.REVIEW]: {
+    title: '리뷰관리',
+    hasBackButton: true,
+  },
 }
 
 export const getNavigationProps = (pathname: string): NavigationProps => {

--- a/src/constants/pendingReviews.ts
+++ b/src/constants/pendingReviews.ts
@@ -1,0 +1,100 @@
+import { PendingReview } from '@/models/review'
+
+export const PENDING_REVIEWS_MOCK_DATA: PendingReview[] = [
+  {
+    orderId: '1',
+    storeId: '1',
+    storeImageUrl: 'https://images.unsplash.com/photo-1547592180-85f173990554',
+    storeName: '매취랑',
+    menus: [{ menuName: '뼈갈비찜', menuCount: 1 }],
+  },
+  {
+    orderId: '2',
+    storeId: '2',
+    storeImageUrl: 'https://images.unsplash.com/photo-1585703900468-13c7a978ad86',
+    storeName: '처갓집양념치킨-성내점',
+    menus: [
+      { menuName: '순살 꼬꼬뱅 슈프림양념치킨', menuCount: 1 },
+      { menuName: '순살 꼬꼬뱅 매운 양념치킨', menuCount: 2 },
+      { menuName: '감자튀김', menuCount: 1 },
+      { menuName: '콜라', menuCount: 1 },
+    ],
+  },
+  {
+    orderId: '3',
+    storeId: '3',
+    storeImageUrl: 'https://images.unsplash.com/photo-1590947132387-155cc02f3212',
+    storeName: '봉구스밥버거',
+    menus: [
+      { menuName: '치즈닭갈비버거', menuCount: 2 },
+      { menuName: '김치제육버거', menuCount: 1 },
+      { menuName: '콜라', menuCount: 2 },
+    ],
+  },
+  {
+    orderId: '4',
+    storeId: '4',
+    storeImageUrl: 'https://images.unsplash.com/photo-1593504049359-74330189a345',
+    storeName: '신전떡볶이',
+    menus: [
+      { menuName: '매운떡볶이', menuCount: 1 },
+      { menuName: '모듬튀김', menuCount: 1 },
+      { menuName: '순대', menuCount: 1 },
+    ],
+  },
+  {
+    orderId: '5',
+    storeId: '5',
+    storeImageUrl: 'https://images.unsplash.com/photo-1590301157890-4810ed352733',
+    storeName: '홍콩반점',
+    menus: [
+      { menuName: '짜장면', menuCount: 2 },
+      { menuName: '탕수육', menuCount: 1 },
+    ],
+  },
+  {
+    orderId: '6',
+    storeId: '6',
+    storeImageUrl: 'https://images.unsplash.com/photo-1576749872435-ff88a71c1ae2',
+    storeName: '서브웨이',
+    menus: [
+      { menuName: '이탈리안 비엠티', menuCount: 1 },
+      { menuName: '에그마요', menuCount: 1 },
+      { menuName: '쿠키', menuCount: 2 },
+    ],
+  },
+  {
+    orderId: '7',
+    storeId: '7',
+    storeImageUrl: 'https://images.unsplash.com/photo-1555396273-367ea4eb4db5',
+    storeName: '교촌치킨',
+    menus: [
+      { menuName: '허니콤보', menuCount: 1 },
+      { menuName: '레드콤보', menuCount: 1 },
+      { menuName: '콜라', menuCount: 2 },
+    ],
+  },
+  {
+    orderId: '8',
+    storeId: '8',
+    storeImageUrl: 'https://images.unsplash.com/photo-1563379926898-05f4575a45d8',
+    storeName: '맥도날드',
+    menus: [
+      { menuName: '빅맥', menuCount: 2 },
+      { menuName: '맥너겟', menuCount: 1 },
+      { menuName: '후렌치 후라이', menuCount: 2 },
+      { menuName: '코카콜라', menuCount: 2 },
+    ],
+  },
+  {
+    orderId: '9',
+    storeId: '9',
+    storeImageUrl: 'https://images.unsplash.com/photo-1584583570840-0a3d88497593',
+    storeName: '본죽',
+    menus: [
+      { menuName: '진영닭죽', menuCount: 1 },
+      { menuName: '전복죽', menuCount: 1 },
+      { menuName: '김치', menuCount: 2 },
+    ],
+  },
+]

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,6 +1,7 @@
 import BANNER_MOCK_DATA from '@/constants/banners'
 import { MENU_MOCK_DATA } from '@/constants/menu'
 import { MENU_OPTIONS_MOCK_DATA } from '@/constants/menuOptions'
+import { PENDING_REVIEWS_MOCK_DATA } from '@/constants/pendingReviews'
 import STORE_MOCK_DATA from '@/constants/stores'
 import { delay, http, HttpResponse, passthrough } from 'msw'
 
@@ -123,6 +124,15 @@ export const handlers = [
       status: 200,
       message: 'success',
       data: MENU_OPTIONS_MOCK_DATA,
+    })
+  }),
+
+  // Get Pending Reviews
+  http.get('/api/reviews/pending', async () => {
+    return HttpResponse.json({
+      status: 200,
+      message: 'success',
+      data: PENDING_REVIEWS_MOCK_DATA,
     })
   }),
 ]

--- a/src/models/review.ts
+++ b/src/models/review.ts
@@ -1,0 +1,19 @@
+import { mockApi } from '@/lib/api'
+import { useQuery } from '@tanstack/react-query'
+
+export interface PendingReview {
+  orderId: string
+  storeId: string
+  storeImageUrl: string
+  storeName: string
+  menus: { menuName: string; menuCount: number }[]
+}
+
+export const usePendingReviews = () => {
+  const res = useQuery<PendingReview[]>({
+    queryKey: ['pendingReviews'],
+    queryFn: () => mockApi.get('api/reviews/pending'),
+  })
+
+  return res
+}

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -10,4 +10,5 @@ export const ROUTE_PATHS = {
   PAY: '/pay',
   MYPAGE: '/mypage',
   STORE_DETAIL: '/store/detail',
+  REVIEW: '/review',
 }


### PR DESCRIPTION
## 작업 내용

> 사진, 코드 등 리뷰어가 쉽게 이해할수 있게 상세히 리뷰어에 입장에서 작성해주요.
> 

### 주요 변경사항
1. 리뷰 관리 페이지 구현
   - 작성 가능한 리뷰와 작성 완료된 리뷰를 탭으로 구분하여 표시
   - 애니메이션이 적용된 탭 전환 기능 구현
   - 리뷰 작성 가능 목록과 작성 완료 목록 표시

2. 컴포넌트 구현
   - `Review.tsx`: 메인 리뷰 페이지 컴포넌트
   - `ReviewTab.tsx`: 리뷰 탭 컴포넌트
   - `PendingReview.tsx`: 작성 가능한 리뷰 아이템 컴포넌트
   - `CompletedReviews.tsx`: 작성 완료된 리뷰 목록 컴포넌트
   - `NoPendingReview.tsx`: 작성 가능한 리뷰가 없을 때 표시되는 컴포넌트
   - `PendingReviewSkeleton.tsx`: 로딩 상태를 표시하는 스켈레톤 컴포넌트

3. API 및 데이터 모델 구현
   - `review.ts`: 리뷰 관련 데이터 모델 및 API 훅 구현
   - Mock API 핸들러 추가
   - 테스트용 mock 데이터 추가

4. 기타 변경사항
   - 네비게이션 설정 추가
   - 라우트 경로 추가
   - 아이콘 컴포넌트에 `UtensilsCrossed` 아이콘 추가



### 스크린샷
(스크린샷이 필요한 경우 추가해주세요)

이 PR을 생성하시겠습니까?


## 이러한 변경이 이루어지는 이유는 무엇인가요?

내용 

## 테스트 방법

> 변경사항에 대해 리뷰어가 테스트할 수 있는 가이드를 step by step으로 제공하세요.
> 

1. `/review` 페이지 접속
2. 작성 가능한 리뷰와 작성 완료된 리뷰 탭 전환 확인
3. 리뷰 목록 표시 및 스켈레톤 로딩 상태 확인
4. 리뷰 작성 버튼 동작 확인

## 병합 전 체크리스트

- [ ]  수정 내용에 오타나 컨벤션이 틀린 부분이 없는지 확인했나요?
- [ ]  추가된 리뷰에 대해 모두 수정 및 재리뷰를 완료했나요?
