### PR TITLE
✨ Feat:  주문 상세, 리뷰 페이지 연동

### DIFF
--- a/src/app/orders/_components/OrderItem.tsx
+++ b/src/app/orders/_components/OrderItem.tsx
@@ -30,15 +30,17 @@ const OrderItem = () => {
           </div>
         </div>
       </div>
-      <div className="flex flex-row justify-center gap-3">
-        <Link className="w-1/2" href={ROUTE_PATHS.ORDER_DETAIL}>
+      <div className="flex flex-row gap-3">
+        <Link className="w-full" href="orders/detail/1">
           <Button size="s" className="h-10">
             주문 상세
           </Button>
         </Link>
-        <Button variant="grayFit" size="s" className="h-10 w-1/2">
-          리뷰 달기
-        </Button>
+        <Link className="w-full" href={ROUTE_PATHS.REVIEW}>
+          <Button variant="grayFit" size="s" className="h-10">
+            리뷰 달기
+          </Button>
+        </Link>
       </div>
     </div>
   )

--- a/src/app/orders/_components/OrderItem.tsx
+++ b/src/app/orders/_components/OrderItem.tsx
@@ -31,7 +31,7 @@ const OrderItem = () => {
         </div>
       </div>
       <div className="flex flex-row gap-3">
-        <Link className="w-full" href="orders/detail/1">
+        <Link className="w-full" href={`${ROUTE_PATHS.ORDERS_DETAIL}/1`}>
           <Button size="s" className="h-10">
             주문 상세
           </Button>

--- a/src/app/orders/detail/[id]/_components/OrderList.tsx
+++ b/src/app/orders/detail/[id]/_components/OrderList.tsx
@@ -1,6 +1,8 @@
 import Chip from '@/components/Chip'
 import Separator from '@/components/Separator'
 import { Button } from '@/components/button'
+import Link from 'next/link'
+import { ROUTE_PATHS } from '@/utils/routes'
 
 const OrderList = () => {
   return (
@@ -27,13 +29,13 @@ const OrderList = () => {
         <div className="text-sm font-bold">주문내역</div>
         <div className="grid grid-cols-2 gap-3">
           <div className="text-[14px]">[주문폭주] 투움바 파스타1</div>
-          <div className="text-[14px] justify-self-end">12,400원</div>
+          <div className="justify-self-end text-[14px]">12,400원</div>
           <div className="max-w-48 text-xs text-gray-500">
             별 다섯개 이벤트+ 포토리뷰 이벤트 참여: 별5점/포토리뷰[355ml 뚱캔콜라]
           </div>
-          <div className="text-xs text-gray-500 justify-self-end">500원</div>
+          <div className="justify-self-end text-xs text-gray-500">500원</div>
           <div className="max-w-48 text-xs text-gray-500">피클 선택</div>
-          <div className="text-xs text-gray-500 justify-self-end">0원</div>
+          <div className="justify-self-end text-xs text-gray-500">0원</div>
         </div>
       </div>
       <Separator className="mb-3 mt-5" />
@@ -74,7 +76,9 @@ const OrderList = () => {
         </div>
       </div>
       <Separator className="mb-3 mt-5" />
-      <Button>확인</Button>
+      <Link href={ROUTE_PATHS.ORDERS}>
+        <Button>확인</Button>
+      </Link>
     </div>
   )
 }

--- a/src/app/orders/detail/[id]/page.tsx
+++ b/src/app/orders/detail/[id]/page.tsx
@@ -2,7 +2,7 @@ import Separator from '@/components/Separator'
 import OrderStatus from '@/app/orders/detail/[id]/_components/OrderStatus'
 import OrderList from '@/app/orders/detail/[id]/_components/OrderList'
 
-const OrderPage = () => {
+const OrderDetailPage = () => {
   return (
     <div className="flex flex-col gap-5">
       <div className="flex flex-col gap-9 pt-5">
@@ -16,4 +16,4 @@ const OrderPage = () => {
   )
 }
 
-export default OrderPage
+export default OrderDetailPage

--- a/src/components/CommonLayout.tsx
+++ b/src/components/CommonLayout.tsx
@@ -61,7 +61,7 @@ const CommonLayout = ({ children }: CommonLayoutProps) => {
 
         if (permissionStatus.state === 'denied') {
           setError(
-            '위치 정보가 차단되어 있습니다.\n 브라우저 설정에서 위치 정보 접근을 허용해주세요.',
+            '위치 정보가 차단되어 있습니다.\n 브라우저 설정에서 위치 정보 접근을 허용해주세요.'
           )
           return
         }
@@ -103,13 +103,13 @@ const CommonLayout = ({ children }: CommonLayoutProps) => {
                     setAddress(address)
                     setIsLoading(false)
                   }
-                },
+                }
               )
             },
             (error) => {
               console.error('위치 정보 에러:', error)
               setError('위치 정보를 가져오는데 실패했습니다.')
-            },
+            }
           )
         }
       } catch (error) {
@@ -127,13 +127,18 @@ const CommonLayout = ({ children }: CommonLayoutProps) => {
   //   if (!address) return <Loading />
 
   if (pathname === ROUTE_PATHS.WELCOME)
-    return <div className="flex h-full flex-col max-w-[480px] min-w-[320px] mx-auto bg-white">{children}</div>
+    return (
+      <div className="mx-auto flex h-full min-w-[320px] max-w-[480px] flex-col bg-white">
+        {children}
+      </div>
+    )
 
   return (
-    <div className="flex h-full flex-col max-w-[480px] min-w-[320px] mx-auto bg-white">
-      {!pathname.startsWith(ROUTE_PATHS.STORE_DETAIL) && (
-        <Navigation {...getNavigationProps(pathname)} />
-      )}
+    <div className="mx-auto flex h-full min-w-[320px] max-w-[480px] flex-col bg-white">
+      {!pathname.startsWith(ROUTE_PATHS.STORE_DETAIL) &&
+        !pathname.startsWith(ROUTE_PATHS.ORDERS_DETAIL) && (
+          <Navigation {...getNavigationProps(pathname)} />
+        )}
       {children}
       {!pathname.startsWith(ROUTE_PATHS.SEARCH) &&
         !pathname.startsWith(ROUTE_PATHS.STORE_DETAIL) && <BottomNavigation />}

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -7,8 +7,8 @@ const buttonVariants = cva('inline-flex items-center justify-center gap-2 whites
   variants: {
     variant: {
       default: 'bg-primary text-white hover:bg-primary/90 w-full px-4',
-      primaryFit: 'w-fit px-4 text-primary border-solid border border-primary',
-      grayFit: 'w-fit px-4 text-gray-400 border-solid border border-gray-400',
+      primaryFit: 'w-full px-4 text-primary border-solid border border-primary',
+      grayFit: 'w-full px-4 text-gray-400 border-solid border border-gray-400',
     },
 
     size: {
@@ -34,7 +34,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     return (
       <button className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
     )
-  },
+  }
 )
 Button.displayName = 'Button'
 

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -6,7 +6,6 @@ export const ROUTE_PATHS = {
   SEARCH_RESULT: '/search/result',
   FAVORITES: '/favorites',
   ORDERS: '/orders',
-  ORDER_DETAIL: '/orders-detail',
   PAY: '/pay',
   MYPAGE: '/mypage',
   STORE_DETAIL: '/store/detail',

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -6,6 +6,7 @@ export const ROUTE_PATHS = {
   SEARCH_RESULT: '/search/result',
   FAVORITES: '/favorites',
   ORDERS: '/orders',
+  ORDERS_DETAIL: '/orders/detail',
   PAY: '/pay',
   MYPAGE: '/mypage',
   STORE_DETAIL: '/store/detail',


### PR DESCRIPTION
## 작업 내용

> 사진, 코드 등 리뷰어가 쉽게 이해할수 있게 상세히 리뷰어에 입장에서 작성해주요.
> 주문 내역쪽 페이지 버튼 연동 작업을 진행했습니다.

내용

## 이러한 변경이 이루어지는 이유는 무엇인가요?

- 폴더 구조 변경으로 인해 작업이 이루어졌습니다.
- commonLayout쪽에 order detail 페이지는 navigate가 작동되지 않도록 했습니다.

## 테스트 방법

> 변경사항에 대해 리뷰어가 테스트할 수 있는 가이드를 step by step으로 제공하세요.
> 
1. 내용

## 병합 전 체크리스트

- [ ]  수정 내용에 오타나 컨벤션이 틀린 부분이 없는지 확인했나요?
- [ ]  추가된 리뷰에 대해 모두 수정 및 재리뷰를 완료했나요?
