### PR TITLE
Feat: 주문 상세에서 주문 페이지로 이동 후 주문 결제까지 flow 연결

### DIFF
--- a/src/api/usePostOrderPay.ts
+++ b/src/api/usePostOrderPay.ts
@@ -1,11 +1,12 @@
 import { api } from '@/lib/api'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 
 export interface OrderPay {
   storeId: string // 가게ID
   roadAddress: string // 주문시점의 도로명주소
   jibunAddress: string // 주문시점의 지번주소
   detailAddress: string // 주문시점의 상세주소
+  excludingSpoonAndFork: boolean // 스푼과 포크 제외 여부
   orderType: 'DELIVERY' | 'PACKING' // 주문타입
   paymentType: 'TOSS_PAY' | 'KAKAO_PAY' // 결제타입
   orderMenus: {
@@ -18,30 +19,18 @@ export interface OrderPay {
   }[] // 주문할 메뉴정보 배열
 }
 
-const usePostOrderPay = (orderPayData: OrderPay) => {
-  const qc = useQueryClient()
-
-  const { data: orderPay, isSuccess } = useQuery({
-    queryKey: ['orderPay'],
-    queryFn: async () => {
-      const accessToken = localStorage.getItem('accessToken')
-      const headers: Record<string, string> = {}
-
-      if (accessToken) {
-        headers.Authorization = accessToken
-      }
-
-      return await api.post<OrderPay>(`orders`, orderPayData, {
-        headers,
-      })
+export interface OrderPayResponse {
+  orderId: string
+  orderSummary: string
+  totalPrice: number
+}
+const usePostOrderPay = () => {
+  return useMutation({
+    mutationKey: ['orderPay'],
+    mutationFn: async (data: OrderPay) => {
+      return await api.post<OrderPayResponse>(`orders`, data)
     },
   })
-
-  const resetPostOrderPay = () => {
-    qc.removeQueries({ queryKey: ['orderPay'] })
-  }
-
-  return { orderPay, isSuccess, resetPostOrderPay }
 }
 
 export default usePostOrderPay

--- a/src/api/usePostPayment.ts
+++ b/src/api/usePostPayment.ts
@@ -1,0 +1,19 @@
+import { api } from '@/lib/api'
+import { useMutation } from '@tanstack/react-query'
+
+export interface Payment {
+  orderId: string
+  paymentKey: string
+  amount: number
+}
+
+const usePostPayment = () => {
+  return useMutation({
+    mutationKey: ['payment'],
+    mutationFn: async (data: Payment) => {
+      return await api.post<{}>(`payments/approve`, data)
+    },
+  })
+}
+
+export default usePostPayment

--- a/src/app/orders/_components/OrderItem.tsx
+++ b/src/app/orders/_components/OrderItem.tsx
@@ -1,9 +1,9 @@
-import Image from 'next/image'
-import { Button } from '@/components/button'
-import Badge from '@/components/Badge'
-import { ROUTE_PATHS } from '@/utils/routes'
-import Link from 'next/link'
 import { OrdersList } from '@/api/useGetOrders'
+import Badge from '@/components/Badge'
+import { Button } from '@/components/button'
+import { ROUTE_PATHS } from '@/utils/routes'
+import Image from 'next/image'
+import Link from 'next/link'
 
 const OrderItem = ({ order }: OrdersList) => {
   return (
@@ -11,9 +11,7 @@ const OrderItem = ({ order }: OrdersList) => {
       <div className="flex flex-row">
         <Image
           className="size-[100px] rounded-xl object-cover object-center"
-          src={
-            'https://flexible.img.hani.co.kr/flexible/normal/970/647/imgdb/resize/2017/0709/149948783091_20170709.JPG'
-          }
+          src={order.imageThumbnail}
           alt="음식점 대표 이미지"
           width={100}
           height={100}

--- a/src/app/orders/detail/[id]/_components/OrderList.tsx
+++ b/src/app/orders/detail/[id]/_components/OrderList.tsx
@@ -1,10 +1,6 @@
 import Chip from '@/components/Chip'
 import Separator from '@/components/Separator'
-import { Button } from '@/components/button'
-import Link from 'next/link'
-import { ROUTE_PATHS } from '@/utils/routes'
 import { v4 as uuidv4 } from 'uuid'
-import React from 'react'
 
 interface OrderDataList {
   ordersData: {
@@ -58,44 +54,59 @@ interface OrderDataList {
 
 const OrderList = ({ ordersData }: OrderDataList) => {
   return (
-    <div className="flex flex-col gap-2.5 px-mobile_safe">
-      <div className="flex flex-row items-center justify-between py-2">
-        <div className="text-[18px] font-bold">{ordersData.storeName}</div>
+    <div className="flex flex-col px-mobile_safe">
+      <div className="flex flex-row items-center justify-between pb-6">
+        <div className="text-xl font-bold">{ordersData.storeName}</div>
         <Chip text="주문 취소" />
       </div>
-      <div className="flex flex-col gap-5 py-2.5 pb-5">
-        <div className="text-sm font-bold">주문정보</div>
+      <div className="flex flex-col gap-5">
+        <div className="text-lg font-bold">주문정보</div>
         <div className="flex flex-col gap-3">
-          <div className="flex flex-row justify-between">
-            <div className="text-xs text-gray-500">주문번호</div>
-            <div className="text-xs text-gray-500">{ordersData.orderId}</div>
+          <div className="flex flex-row justify-between gap-8">
+            <div className="min-w-[50px] text-sm text-gray-500">주문번호</div>
+            <div className="text-sm text-gray-500 truncate">{ordersData.orderId}</div>
           </div>
-          <div className="flex flex-row justify-between">
-            <div className="text-xs text-gray-500">주문시간</div>
-            <div className="text-xs text-gray-500">
+          <div className="flex flex-row justify-between gap-8">
+            <div className="text-sm text-gray-500">주문시간</div>
+            <div className="text-sm text-gray-500">
               {new Date(ordersData.orderTime).toLocaleString()}
             </div>
           </div>
         </div>
       </div>
-      <Separator className="mb-3 mt-5" />
-      <div className="flex flex-col gap-5 py-2.5">
-        <div className="text-sm font-bold">주문내역</div>
-        <div className="grid grid-cols-2 gap-3">
+      <Separator className="my-5" />
+      <div className="flex flex-col gap-5">
+        <div className="text-lg font-bold">주문내역</div>
+        {ordersData.orderMenus.map((menu) => (
+          <div key={uuidv4()}>
+            <p className='text-base font-semibold'>{`${menu.menuName} ${menu.menuQuantity}개`}</p>
+            <ul className='pt-1 list-disc pl-4 space-y-0.5 [&>li]:pl-0 [&>li]:-indent-1 text-gray-500'>
+              <li className='text-sm'>{`기본 : ${(menu.menuPrice * menu.menuQuantity).toLocaleString()}원`}</li>
+              {menu.orderMenuOptionGroups.map((menuGroup) => (
+                menuGroup.orderMenuOptions.map((menuOption) => {
+                  return <li key={uuidv4()} className='text-sm'>{`${menuGroup.orderMenuOptionGroupName} : ${menuOption.menuOptionName} (${(menuOption.menuOptionPrice * menu.menuQuantity).toLocaleString()}원)`}</li>
+                })
+              ))}
+            </ul>
+          </div>
+        ))}
+
+        {/* <div className="grid grid-cols-2 gap-3">
           {ordersData.orderMenus.map((menu) => (
             <React.Fragment key={uuidv4()}>
               <div className="text-[14px]" key={uuidv4()}>
-                {menu.menuName}
+                {`${menu.menuName} ${menu.menuQuantity}개`}
               </div>
               <div
                 className="justify-self-end text-[14px]"
                 key={uuidv4()}
-              >{`${menu.menuPrice.toLocaleString()}원`}</div>
+              >{`${(menu.menuPrice * menu.menuQuantity).toLocaleString()}원`}</div>
               {menu.orderMenuOptionGroups.map((menuDetail) => (
                 <React.Fragment key={uuidv4()}>
                   <div className="max-w-48 text-xs text-gray-500" key={uuidv4()}>
                     {menuDetail.orderMenuOptionGroupName}
                   </div>
+                  <div>
                   {menuDetail.orderMenuOptions.map((menuOption) => (
                     <React.Fragment key={uuidv4()}>
                       <div
@@ -104,53 +115,58 @@ const OrderList = ({ ordersData }: OrderDataList) => {
                       >{`${menuOption.menuOptionPrice.toLocaleString()}원`}</div>
                     </React.Fragment>
                   ))}
+                  </div>
                 </React.Fragment>
               ))}
             </React.Fragment>
           ))}
-        </div>
+        </div> */}
       </div>
-      <Separator className="mb-3 mt-5" />
+
+      <Separator className="my-5" />
+
       <div className="flex flex-col gap-5">
         <div className="flex flex-row items-center justify-between">
-          <div className="text-[14px]">상품금액</div>
-          <div className="text-[14px]">{`${ordersData.orderPrice.toLocaleString()}원`}</div>
+          <div className="text-base">상품금액</div>
+          <div className="text-base">{`${ordersData.orderPrice.toLocaleString()}원`}</div>
         </div>
       </div>
-      <Separator className="mb-3 mt-5" />
+
+      <Separator className="my-5" />
+
       <div className="flex flex-col gap-5">
         <div className="flex flex-row justify-between">
-          <div className="text-[14px]">배달요금</div>
-          <div className="text-[14px]">{`${ordersData.deliveryPrice.toLocaleString()}원`}</div>
+          <div className="text-base">배달요금</div>
+          <div className="text-base">{`${ordersData.deliveryPrice.toLocaleString()}원`}</div>
         </div>
       </div>
-      <Separator className="mb-3 mt-5" />
+
+      <Separator className="my-5" />
+
       <div className="flex flex-col gap-5">
         <div className="flex flex-row justify-between">
-          <div className="text-[14px]">총 결제 금액</div>
-          <div className="text-[14px]">{`${ordersData.paymentPrice.toLocaleString()}원`}</div>
+          <div className="text-base">총 결제 금액</div>
+          <div className="text-base">{`${ordersData.paymentPrice.toLocaleString()}원`}</div>
         </div>
         <div className="flex flex-row justify-between">
-          <div className="max-w-48 text-xs text-gray-500">결제방식</div>
-          <div className="text-xs text-gray-500">{ordersData.paymentType.desc}</div>
+          <div className="text-sm text-gray-500">결제방식</div>
+          <div className="text-sm text-gray-500">{ordersData.paymentType.desc}</div>
         </div>
       </div>
-      <Separator className="mb-3 mt-5" />
-      <div className="text-sm font-bold">주문자 정보</div>
-      <div className="flex flex-col gap-3">
+
+      <Separator className="my-5" />
+
+      <div className="text-lg font-bold pb-5">주문자 정보</div>
+      <div className="flex flex-col gap-3 pb-16">
         <div className="flex flex-row justify-between">
-          <div className="max-w-48 text-xs text-gray-500">연락처</div>
-          <div className="text-xs text-gray-500">{ordersData.tel}</div>
+          <div className="max-w-48 text-sm text-gray-500">연락처</div>
+          <div className="text-sm text-gray-500">{ordersData.tel}</div>
         </div>
         <div className="flex flex-row justify-between">
-          <div className="max-w-48 text-xs text-gray-500">주소</div>
-          <div className="text-xs text-gray-500">{ordersData.roadAddress}</div>
+          <div className="text-sm text-gray-500">주소</div>
+          <div className="text-sm text-gray-500">{ordersData.roadAddress}</div>
         </div>
       </div>
-      <Separator className="mb-3 mt-5" />
-      <Link href={ROUTE_PATHS.ORDERS}>
-        <Button>확인</Button>
-      </Link>
     </div>
   )
 }

--- a/src/app/orders/detail/[id]/_components/OrderStatus.tsx
+++ b/src/app/orders/detail/[id]/_components/OrderStatus.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useEffect, useState } from 'react'
 import { Progress } from '@/components/shadcn/progress'
+import { useEffect, useState } from 'react'
 
 type OrderStatusProps = {
   orderStatus?: string | null
@@ -14,7 +14,6 @@ const OrderStatus: React.FC<OrderStatusProps> = ({ orderStatus }) => {
   const [value, setValue] = useState(0)
 
   useEffect(() => {
-    console.log('status', status)
     switch (status) {
       case '주문거절':
         setTitle('주문이 거절되었습니다.')

--- a/src/app/pay/_components/MenuItem.tsx
+++ b/src/app/pay/_components/MenuItem.tsx
@@ -1,38 +1,44 @@
-import Image from 'next/image'
 import Icon from '@/components/Icon'
-import { Button } from '@/components/button'
 import UpDownBtn from '@/components/UpDownBtn'
+import { OrderMenu } from '@/store/orderList'
+import Image from 'next/image'
+import { useState } from 'react'
 
-const MenuItem = () => {
+const MenuItem = ({ menu, handlePriceAndCount }: { menu: OrderMenu, handlePriceAndCount: (id: string, count: number) => void }) => {
+  const [count, setCount] = useState(1)
+
+  const handlerCount = (count: number) => {
+    setCount(count)
+    handlePriceAndCount(menu.menuId, count)
+  }
+
   return (
-    <div>
+    <div className='px-3 flex flex-col gap-2'>
       <div className="flex flex-row justify-between">
-        <div className="ml-5 flex flex-row gap-2">
+        <div className="flex flex-row gap-3">
           <Image
             className="size-[60px] rounded-xl object-cover object-center"
-            src={
-              'https://flexible.img.hani.co.kr/flexible/normal/970/647/imgdb/resize/2017/0709/149948783091_20170709.JPG'
-            }
+            src={menu.imgUrl}
             alt="음식점 대표 이미지"
             width={60}
             height={60}
             loading="lazy"
           />
-          <div className="flex flex-col place-content-center gap-2">
-            <div>맵소디</div>
-            <div className="text-sm text-gray-700">한마리</div>
-            <div className="font-bold">24,500원</div>
+          <div className="flex flex-col place-content-center">
+            <div className="text-base font-medium">{menu.name}</div>
+            <div className="text-sm text-gray-700 pb-3">{menu.optionNames}</div>
+            <div className="font-bold">{(menu.price * count).toLocaleString()}원</div>
           </div>
         </div>
-        <div className="mr-5">
+        <div className="">
           <Icon name="X" size={20} className="text-gray-700" />
         </div>
       </div>
-      <div className="mr-5 flex flex-row justify-end gap-2 py-2">
+      <div className="flex flex-row justify-end gap-2">
         {/*<Button variant="grayFit" size="s" className="text-black">*/}
         {/*  옵션변경*/}
         {/*</Button>*/}
-        <UpDownBtn value={1} />
+        <UpDownBtn value={count} handlerCount={handlerCount} />
       </div>
     </div>
   )

--- a/src/app/pay/_components/OrderInfo.tsx
+++ b/src/app/pay/_components/OrderInfo.tsx
@@ -1,38 +1,154 @@
 'use client'
 
 import usePostOrderPay, { OrderPay } from '@/api/usePostOrderPay'
+import usePostPayment from '@/api/usePostPayment'
 import MenuItem from '@/app/pay/_components/MenuItem'
+import Alert from '@/components/Alert'
 import { Button } from '@/components/button'
+import Confirm from '@/components/Confirm'
 import Icon from '@/components/Icon'
 import Separator from '@/components/Separator'
 import { Checkbox } from '@/components/shadcn/checkbox'
+import { Label } from '@/components/shadcn/label'
+import { modalStore } from '@/store/modal'
+import { orderListStore } from '@/store/orderList'
+import memberStore from '@/store/user'
+import { ROUTE_PATHS } from '@/utils/routes'
+import { useRouter } from 'next/navigation'
+import { useEffect, useRef, useState } from 'react'
 
 const OrderInfo = () => {
-  const orderData: OrderPay = {
-    storeId: '26466355',
-    roadAddress: '서울특별시 강남구 테헤란로 123',
-    jibunAddress: '서울특별시 강남구 역삼동 123-45',
-    detailAddress: '101호',
-    orderType: 'DELIVERY',
-    paymentType: 'TOSS_PAY',
-    orderMenus: [
-      {
-        id: '9e15c3da-cae8-4c25-8b4e-ae21a926f072',
-        quantity: 2,
-        orderMenuOptionGroups: [
-          {
-            id: '62f5ab82-6f9f-4344-964c-9a09a568df62',
-            orderMenuOptionIds: ['c5d18e3d-e643-49d6-b089-3dbb5a148800'],
-          },
-        ],
-      },
-    ],
+  const router = useRouter()
+
+  const { orderList, removeOrderList } = orderListStore()
+  const { member } = memberStore()
+  const { showModal, hideModal, modals } = modalStore()
+
+  const isFirstRender = useRef(true)
+
+  const [isExcludingSpoon, setIsExcludingSpoon] = useState(false)
+  const [deliveryPrice, setDeliveryPrice] = useState(0)
+  const [menuPriceAndCount, setMenuPriceAndCount] = useState<Record<string, { count: number, price: number }>>({})
+
+  // const orderData: OrderPay = {
+  //   storeId: '26466355',
+  //   roadAddress: '서울특별시 강남구 테헤란로 123',
+  //   jibunAddress: '서울특별시 강남구 역삼동 123-45',
+  //   detailAddress: '101호',
+  //   excludingSpoonAndFork: isExcludingSpoon,
+  //   orderType: 'DELIVERY',
+  //   paymentType: 'TOSS_PAY',
+  //   orderMenus: [
+  //     {
+  //       id: '9e15c3da-cae8-4c25-8b4e-ae21a926f072',
+  //       quantity: 2,
+  //       orderMenuOptionGroups: [
+  //         {
+  //           id: '62f5ab82-6f9f-4344-964c-9a09a568df62',
+  //           orderMenuOptionIds: ['c5d18e3d-e643-49d6-b089-3dbb5a148800'],
+  //         },
+  //       ],
+  //     },
+  //   ],
+  // }
+
+  const { mutate: orderPay, isSuccess, data: orderResponse } = usePostOrderPay()
+  const { mutate: payment, isSuccess: paymentSuccess } = usePostPayment()
+
+  const handleOrderPay = () => {
+    if (!orderList || !member) {
+      showModal({
+        content: <Alert title="주문 오류" message="주문에 필요한 정보가 없습니다." onClick={() => router.back()} />,
+      })
+      return
+    }
+
+    let orderData: OrderPay = {
+      storeId: orderList.storeId,
+      roadAddress: member.roadAddress || '',
+      jibunAddress: member.jibunAddress || '',
+      detailAddress: member.detailAddress || '',
+      excludingSpoonAndFork: isExcludingSpoon,
+      orderType: 'DELIVERY',
+      paymentType: 'TOSS_PAY',
+      orderMenus: orderList.menu.map((item) => {
+        return {
+          id: item.menuId,
+          quantity: menuPriceAndCount[item.menuId].count,
+          orderMenuOptionGroups: Object.keys(item.selectedOptions).map(group => ({
+            id: group,
+            orderMenuOptionIds: item.selectedOptions[group].map(option => option.id),
+          })),
+        }
+      }),
+    }
+
+    orderPay(orderData)
   }
 
-  const { orderPay, isSuccess } = usePostOrderPay(orderData)
+  const handlePriceAndCount = (id: string, count: number) => {
+    setMenuPriceAndCount(prev => {
+      const currentPriceAndCount = prev[id] || { count: 0, price: 0 }
+      return {
+        ...prev,
+        [id]: { count: count, price: currentPriceAndCount.price },
+      }
+    })
+  }
 
-  if (isSuccess) {
-    console.log('주문 성공:', orderPay)
+  const getPrice = () => {
+    return Object.values(menuPriceAndCount).reduce((acc, menu) => {
+      return acc + menu.price * menu.count
+    }, 0)
+  }
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false
+
+      if (!orderList && modals.length === 0) {
+        showModal({
+          content: <Alert title="주문 오류" message="주문 목록을 추가해주세요." onClick={() => router.back()} />,
+        })
+
+        return
+      }
+
+      setMenuPriceAndCount(orderList?.menu.reduce((acc, menu) => {
+        acc[menu.menuId] = {
+          count: 1,
+          price: menu.price,
+        }
+        return acc
+      }, {} as Record<string, { count: number, price: number }>) || {})
+    }
+  }, [])
+
+  useEffect(() => {
+    if (orderResponse) {
+      payment({
+        orderId: orderResponse.orderId,
+        paymentKey: '',
+        amount: orderResponse.totalPrice,
+      })
+    }
+  }, [orderResponse])
+
+  useEffect(() => {
+    if (paymentSuccess) {
+      showModal({
+        content: <Confirm title="주문 완료" message="주문이 완료되었습니다.<br />주문 내역을 확인하러갈까요?"
+          confirmText='확인하러 가기' onConfirmClick={() => {
+            removeOrderList()
+            router.push(`${ROUTE_PATHS.ORDERS_DETAIL}/${orderResponse?.orderId}`)
+          }}
+          cancelText='홈으로' onCancelClick={() => router.push(ROUTE_PATHS.HOME)} />,
+      })
+    }
+  }, [paymentSuccess])
+
+  if (!orderList) {
+    return null
   }
 
   return (
@@ -51,26 +167,25 @@ const OrderInfo = () => {
       <div className="flex flex-row justify-between">
         <div className="flex flex-row gap-2">
           <Icon name="MapPin" size={24} />
-          <div className="place-content-center text-sm font-bold">세종대로 14</div>
+          <div className="place-content-center text-sm font-bold">{member?.roadAddress}</div>
           <div className="place-content-center text-xs">(으)로 배달</div>
         </div>
         <Icon name="ChevronRight" size={24} />
       </div>
       <div>
-        <div className="ml-7 text-xs text-gray-700">서울특별시 강남구 테헤란로 123</div>
+        <div className="ml-7 text-xs text-gray-700">{member?.jibunAddress}</div>
       </div>
       <div className="rounded-xl border border-solid border-gray-400">
-        <div className="flex flex-row justify-between p-5">
-          <div className="text-base font-extrabold">BBQ-남대문점</div>
+        <div className="flex flex-row justify-between px-3 py-3 border-b border-solid border-gray-300">
+          <div className="text-base font-extrabold">{orderList.storeName}</div>
           <div className="place-content-center text-xs text-gray-700">전체삭제</div>
         </div>
-        <Separator className="mb-5" />
-        <div className="flex flex-col gap-1">
-          <MenuItem />
-          <MenuItem />
+
+        <div className="flex flex-col gap-1 py-4">
+          {orderList.menu.map((item) => <MenuItem key={item.menuId} menu={item} handlePriceAndCount={handlePriceAndCount} />)}          
         </div>
-        <Separator className="my-5" />
-        <div className="mb-5 flex flex-row items-center justify-center gap-1">
+
+        <div className="flex flex-row items-center justify-center gap-1 px-3 py-3 border-t border-solid border-gray-300">
           <Icon name="Plus" size={20} />
           <div className="font-bold">메뉴 추가하기</div>
         </div>
@@ -78,16 +193,16 @@ const OrderInfo = () => {
       <div className="flex flex-col gap-4 rounded-xl border border-solid border-gray-400 p-5">
         <div className="text-base font-extrabold">가게 요청사항</div>
         {/* <Input placeholder="예) 견과류 빼주세요" /> */}
-        <div className="items-top flex space-x-2">
-          <Checkbox id="terms1" />
-          <div className="grid gap-1.5 leading-none">
-            <label
+        <div className="items-top flex items-center space-x-2">
+          <Checkbox id="terms1" className="h-5 w-5 border-solid data-[state=checked]:bg-white data-[state=checked]:border-primary border-gray-300 outline-none"
+            checked={isExcludingSpoon}
+            onCheckedChange={(checked: boolean) => setIsExcludingSpoon(checked)} />
+          <Label
               htmlFor="terms1"
-              className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+            className="text-sm font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
             >
               일회용 수저, 포크는 빼주세요
-            </label>
-          </div>
+          </Label>
         </div>
         <Separator />
         <div className="flex flex-row justify-between">
@@ -110,19 +225,19 @@ const OrderInfo = () => {
       <div className="flex flex-col gap-2 px-1">
         <div className="flex flex-row justify-between">
           <div>상품금액</div>
-          <div>24,500원</div>
+          <div>{getPrice().toLocaleString()}원</div>
         </div>
         <div className="flex flex-row justify-between">
           <div>배달요금</div>
-          <div>0원</div>
+          <div>{deliveryPrice.toLocaleString()}원</div>
         </div>
       </div>
       <Separator />
       <div className="flex flex-row justify-between px-1">
         <div className="text-lg font-bold">총 결재금액</div>
-        <div className="text-lg font-bold">27,500원</div>
+        <div className="text-lg font-bold">{(getPrice() + deliveryPrice).toLocaleString()}원</div>
       </div>
-      <Button>27,500원 배달 결제하기</Button>
+      <Button onClick={handleOrderPay}>{(getPrice() + deliveryPrice).toLocaleString()}원 배달 결제하기</Button>
     </div>
   )
 }

--- a/src/app/store/detail/[id]/_components/StoreDetail.tsx
+++ b/src/app/store/detail/[id]/_components/StoreDetail.tsx
@@ -281,7 +281,7 @@ const StoreDetail = ({ storeId }: { storeId: number }) => {
                 {category.categoryName}
               </p>
               {category.menus.map((menu) => (
-                <StoreDetailMenuItem key={menu.id} storeId={storeDetail?.id || ''} menu={menu} />
+                <StoreDetailMenuItem key={menu.id} storeName={storeDetail?.name || ''} storeId={storeDetail?.id || ''} menu={menu} />
               ))}
             </div>
           ))}

--- a/src/app/store/detail/[id]/_components/StoreDetailMenuItem.tsx
+++ b/src/app/store/detail/[id]/_components/StoreDetailMenuItem.tsx
@@ -7,7 +7,7 @@ import { Menu } from '@/models/menu'
 import { orderDetailStore } from '@/store/orderDetail'
 import Image from 'next/image'
 
-const StoreDetailMenuItem = ({ storeId, menu }: { storeId: string, menu: Menu }) => {
+const StoreDetailMenuItem = ({ storeName, storeId, menu }: { storeName: string, storeId: string, menu: Menu }) => {
     const { showOrderDetail } = orderDetailStore()
     const { toast } = useToast()
 
@@ -24,6 +24,7 @@ const StoreDetailMenuItem = ({ storeId, menu }: { storeId: string, menu: Menu })
         const rect = imgWrapper?.getBoundingClientRect()
         showOrderDetail({
             storeId: storeId,
+            storeName: storeName,
             menuId: menu.id,
             originX: rect?.left ?? 0,
             originY: rect?.top ?? 0,

--- a/src/app/store/detail/[id]/_components/StoreOrderDetail.tsx
+++ b/src/app/store/detail/[id]/_components/StoreOrderDetail.tsx
@@ -97,14 +97,16 @@ const StoreOrderDetail = () => {
 
         setOrderList({
             storeId: orderDetail?.storeId.toString() ?? 'aa',
+            storeName: orderDetail?.storeName ?? '',
             price: price,
-            menu: {
+            menu: [{
                 menuId: storeMenuOptions?.menuId ?? '',
                 name: storeMenuOptions?.name ?? '',
                 imgUrl: storeMenuOptions?.imgUrl ?? '',
                 optionNames: Object.values(selectedOptions).map(options => options.map(option => option.name).join(', ')).join(', '),
+                price: price,
                 selectedOptions
-            },
+            }],
         })
 
         router.push(ROUTE_PATHS.PAY)
@@ -281,7 +283,7 @@ const StoreOrderDetail = () => {
                         delay: 0.2
                     }}
                 >
-                    <p className="text-sm text-center text-red-600 font-bold py-4">18,000원부터 배달 가능해요</p>
+                    <p className="text-sm text-center text-red-600 font-bold py-4">5,000원부터 배달 가능해요</p>
                     <Button className={cn("text-base font-semibold", !isValid && "bg-gray-400 hover:bg-gray-400")} onClick={handleOrder} >{price.toLocaleString()}원 주문하기</Button>
                 </motion.div>
             </div>,

--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -1,0 +1,32 @@
+import { modalStore } from '@/store/modal'
+import { Button } from './button'
+
+interface AlertProps {
+    title: string
+    message: string
+    onClick: () => void
+    cancelText?: string
+}
+
+const Alert = ({ title, message, onClick, cancelText }: AlertProps) => {
+    const { hideModal } = modalStore()
+
+    const handleClick = () => {
+        hideModal()
+        onClick()
+    }
+
+    return (
+        <div className='w-[70%] max-w-[440px] min-h-[150px] flex flex-col gap-6 bg-white rounded-xl p-5'>
+            <div className='flex flex-col flex-1 gap-2'>
+                <div className='text-lg font-bold text-center'>{title}</div>
+                <div className='text-base text-center'>{message}</div>
+            </div>
+            <div>
+                <Button onClick={handleClick}>{cancelText || '확인'}</Button>
+            </div>
+        </div>
+    )
+}
+
+export default Alert

--- a/src/components/CommonLayout.tsx
+++ b/src/components/CommonLayout.tsx
@@ -31,6 +31,14 @@ const CommonLayout = ({ children }: CommonLayoutProps) => {
     useGeoLocationStore()
   const pathname = usePathname()
 
+  const HIDDEN_BOTTOM_NAV_PATHS = [
+    ROUTE_PATHS.SEARCH,
+    ROUTE_PATHS.STORE_DETAIL,
+    ROUTE_PATHS.MYPAGE_EDIT_PROFILE,
+    ROUTE_PATHS.PAY,
+    ROUTE_PATHS.ORDERS_DETAIL,
+  ]
+
   const { storedValue: accessToken } = useLocalStorage('accessToken')
   const { data: memberData, isFetching, refetch } = useGetMember()
   const { mutate: logout } = usePostLogout()
@@ -170,14 +178,11 @@ const CommonLayout = ({ children }: CommonLayoutProps) => {
 
   return (
     <div className="mx-auto flex h-full min-w-[320px] max-w-[480px] flex-col bg-white">
-      {!pathname.startsWith(ROUTE_PATHS.STORE_DETAIL) &&
-        !pathname.startsWith(ROUTE_PATHS.ORDERS_DETAIL) && (
+      {!pathname.startsWith(ROUTE_PATHS.STORE_DETAIL) && (
           <Navigation {...getNavigationProps(pathname)} />
         )}
       {children}
-      {!pathname.startsWith(ROUTE_PATHS.SEARCH) &&
-        !pathname.startsWith(ROUTE_PATHS.STORE_DETAIL) &&
-        !pathname.startsWith(ROUTE_PATHS.MYPAGE_EDIT_PROFILE) && <BottomNavigation />}
+      {!HIDDEN_BOTTOM_NAV_PATHS.some((path) => pathname.startsWith(path)) && <BottomNavigation />}
     </div>
   )
 }

--- a/src/components/Confirm.tsx
+++ b/src/components/Confirm.tsx
@@ -1,0 +1,43 @@
+import { modalStore } from '@/store/modal'
+import { Button } from './button'
+
+interface ConfirmProps {
+    title: string
+    message: string
+    onConfirmClick: () => void
+    onCancelClick?: () => void
+    cancelText?: string
+    confirmText?: string
+}
+
+const Confirm = ({ title, message, onConfirmClick, onCancelClick, cancelText, confirmText }: ConfirmProps) => {
+    const { hideModal } = modalStore()
+
+    const handleConfirmClick = () => {
+        hideModal()
+        onConfirmClick()
+    }
+
+    const handleCancelClick = () => {
+        onCancelClick?.()
+        hideModal()
+    }
+
+    return (
+        <div className='w-[70%] max-w-[440px] min-h-[150px] flex flex-col gap-6 bg-white rounded-xl p-5'>
+            <div className='flex flex-col flex-1 gap-2'>
+                <div className='text-lg font-bold text-center'>{title}</div>
+                <div
+                    className='text-base text-center'
+                    dangerouslySetInnerHTML={{ __html: message }}
+                />
+            </div>
+            <div className='flex flex-row gap-2'>
+                <Button className='w-[50%]' onClick={handleConfirmClick}>{confirmText || '확인'}</Button>
+                <Button className='w-[50%]' variant='grayFit' onClick={handleCancelClick}>{cancelText || '취소'}</Button>
+            </div>
+        </div>
+    )
+}
+
+export default Confirm 

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -30,7 +30,7 @@ const Modal = () => {
                   {modal.content}
                 </motion.div> 
                 :
-                <div className="relative z-10 max-w-[480px] min-w-[320px] h-full mx-auto">
+                <div className="relative z-10 max-w-[480px] min-w-[320px] h-full mx-auto flex items-center justify-center">
                   {modal.content}
                 </div>
               }

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -6,6 +6,7 @@ import Icon from './Icon'
 
 export interface NavigationProps {
   hasBackButton?: boolean
+  redirectPath?: string
   title?: string
   centerElement?: React.ReactNode
   rightElement?: React.ReactNode
@@ -15,6 +16,7 @@ export interface NavigationProps {
 
 const Navigation = ({
   hasBackButton,
+  redirectPath,
   title,
   centerElement,
   rightElement,
@@ -25,10 +27,16 @@ const Navigation = ({
   const { address } = useGeoLocationStore()
 
   return (
-    <nav className="mt-3 flex h-navigation items-center justify-center gap-[8px] border-b bg-white px-mobile_safe">
+    <nav className={`mt-3 flex h-navigation items-center justify-center gap-[8px] bg-white px-mobile_safe`}>
       <div className="flex h-full w-[24px] items-center justify-center">
         {hasBackButton && (
-          <button onClick={() => router.back()}>
+          <button onClick={() => {
+            if (redirectPath) {
+              router.push(redirectPath)
+            } else {
+              router.back()
+            }
+          }}>
             <Icon name="ChevronLeft" size={24} />
           </button>
         )}

--- a/src/components/UpDownBtn.tsx
+++ b/src/components/UpDownBtn.tsx
@@ -1,31 +1,29 @@
 'use client'
 
 import Icon from '@/components/Icon'
-import { useState } from 'react'
 
 interface UpDownProps {
-  value?: number
+  value: number
+  handlerCount: (count: number) => void
 }
 
-const UpDownBtn = ({ value = 0 }: UpDownProps) => {
-  const [counter, setCount] = useState<number>(value)
-
-  const onMinus = (counter: number) => {
-    if (counter <= 0) {
-      return counter
-    } else {
-      return counter - 1
+const UpDownBtn = ({ value = 0, handlerCount }: UpDownProps) => {
+  const onChangeCount = (count: number) => {
+    if (count <= 0) {
+      return
     }
+
+    handlerCount(count)
   }
 
   return (
-    <div className="flex flex-row items-center rounded border border-solid border-gray-400 px-2">
-      <button onClick={() => setCount(onMinus(counter))}>
-        <Icon name="Minus" size={20} className="text-gray-400" />
+    <div className="flex flex-row items-center h-8 rounded-lg border border-solid border-gray-300 px-2">
+      <button className='flex items-center justify-center' onClick={() => onChangeCount(value - 1)}>
+        <Icon name="Minus" size={18} color={value <= 1 ? 'gray' : 'black'} />
       </button>
-      <div className="mx-2 w-3 place-content-center">{counter}</div>
-      <button onClick={() => setCount(counter + 1)}>
-        <Icon name="Plus" size={20} />
+      <div className="flex items-center justify-center mx-2 w-4 text-sm font-bold">{value}</div>
+      <button className='flex items-center justify-center' onClick={() => onChangeCount(value + 1)}>
+        <Icon name="Plus" size={18} color={value >= 99 ? 'gray' : 'black'} />
       </button>
     </div>
   )

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -8,7 +8,7 @@ const buttonVariants = cva('inline-flex items-center justify-center gap-2 whites
     variant: {
       default: 'bg-primary text-white hover:bg-primary/90 w-full px-4',
       primaryFit: 'w-full px-4 text-primary border-solid border border-primary',
-      grayFit: 'w-full px-4 text-gray-400 border-solid border border-gray-400',
+      grayFit: 'w-full px-4 text-gray-800 border-solid border border-gray-400',
     },
 
     size: {

--- a/src/constants/navigationProps.tsx
+++ b/src/constants/navigationProps.tsx
@@ -50,6 +50,7 @@ const NAVIGATION_PROPS: Record<string, NavigationProps> = {
   },
   [ROUTE_PATHS.PAY]: {
     title: '주문하기',
+    hasBackButton: true,
   },
   [ROUTE_PATHS.MYPAGE_EDIT_PROFILE]: {
     hasBackButton: true,
@@ -59,10 +60,17 @@ const NAVIGATION_PROPS: Record<string, NavigationProps> = {
     title: '리뷰관리',
     hasBackButton: true,
   },
+  [ROUTE_PATHS.ORDERS_DETAIL]: {
+    title: '주문상세',
+    hasBackButton: true,
+    redirectPath: ROUTE_PATHS.ORDERS,
+  },
 }
 
 export const getNavigationProps = (pathname: string): NavigationProps => {
-  return NAVIGATION_PROPS[pathname] || NAVIGATION_PROPS[ROUTE_PATHS.HOME]
+  // UUID나 숫자 등 동적 라우팅 패턴 처리
+  const normalizedPath = pathname.replace(/\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|\/\d+/g, '')
+  return NAVIGATION_PROPS[normalizedPath] || NAVIGATION_PROPS[ROUTE_PATHS.HOME]
 }
 
 export default NAVIGATION_PROPS

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -171,6 +171,10 @@ export const handlers = [
     return passthrough()
   }),
 
+  http.post('*/api/v1/orders', () => {
+    return passthrough()
+  }),
+
   // Get Menu Options
   http.get('/api/v1/stores/:id/menus/:menuId/options', async ({ request }) => {
     return passthrough()

--- a/src/models/auth.ts
+++ b/src/models/auth.ts
@@ -22,4 +22,7 @@ export interface Member {
   signname: string
   nickname: string
   profileImage: string
+  roadAddress?: string
+  jibunAddress?: string
+  detailAddress?: string
 }

--- a/src/store/orderDetail.ts
+++ b/src/store/orderDetail.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 
 interface OrderDetail {
   storeId: string
+  storeName: string
   menuId: string  
   imageUrl: string
   originX: number

--- a/src/store/orderList.ts
+++ b/src/store/orderList.ts
@@ -1,18 +1,30 @@
-import { MenuGroupOption, MenuOption } from "@/models/menu";
+import { MenuGroupOption } from "@/models/menu";
 import { create } from "zustand";
+
+export interface OrderMenu {
+    menuId: string
+    name: string
+    imgUrl: string
+    optionNames: string
+    selectedOptions: Record<string, MenuGroupOption[]>
+    price: number
+}
 
 interface Order {
     storeId: string
+    storeName: string
     price: number
-    menu: Pick<MenuOption, 'menuId' | 'name' | 'imgUrl'> & { optionNames: string, selectedOptions: Record<string, MenuGroupOption[]>}
+    menu: OrderMenu[]
 }
 
 interface OrderList {
     orderList: Order | undefined
     setOrderList: (orderList: Order) => void
+    removeOrderList: () => void
 }
 
 export const orderListStore = create<OrderList>((set) => ({
     orderList: undefined,
     setOrderList: (orderList) => set({ orderList }),
+    removeOrderList: () => set({ orderList: undefined }),
 }))

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -9,7 +9,7 @@ interface UserStore {
 
 const memberStore = create<UserStore>((set) => ({
   member: null,
-  setMember: (member: Member) => set({ member }),
+  setMember: (member: Member) => set({ member: {...member, roadAddress: '서울특별시 강남구 테헤란로 123', jibunAddress: '서울특별시 강남구 역삼동 123-45', detailAddress: '101호'} }),
   resetMember: () => set({ member: null }),
 }))
 


### PR DESCRIPTION
## 작업 내용

주문 생성 기능을 구현했습니다.

### 1. 주문 상세 페이지 UI 개선
- 주문 내역 레이아웃 개선
- 메뉴 옵션 표시 방식 변경
- 폰트 크기 및 여백 조정

### 2. 주문 생성 기능 추가
- 메뉴 수량 조절 기능 구현
- 일회용 수저/포크 옵션 추가
- 주문 금액 계산 로직 구현
- 결제 API 연동

### 3. 컴포넌트 추가
- Alert 컴포넌트 추가
- Confirm 컴포넌트 추가
- UpDownBtn 컴포넌트 개선

### 4. 네비게이션 개선
- redirectPath 속성 추가
- 하단 네비게이션 숨김 처리 로직 개선

## 이러한 변경이 이루어지는 이유는 무엇인가요?

1. 사용자가 메뉴를 선택하고 주문할 수 있는 기능이 필요했습니다.
2. 주문 과정에서 필요한 UI/UX 개선이 필요했습니다.
3. 주문 완료 후 결제 프로세스 연동이 필요했습니다.
4. 주문 관련 페이지들의 네비게이션 동작을 개선할 필요가 있었습니다.

## 테스트 방법

1. 메뉴 상세 페이지에서 메뉴 선택
   - 메뉴 옵션 선택
   - 수량 조절 확인
   - 주문하기 버튼 클릭

2. 주문하기 페이지 확인
   - 선택한 메뉴 및 옵션 표시 확인
   - 수량 조절 기능 확인
   - 일회용 수저/포크 옵션 선택 확인
   - 금액 계산 확인

3. 결제 프로세스 확인
   - 결제하기 버튼 클릭
   - 결제 완료 후 주문 상세 페이지로 이동 확인
   - 주문 상세 페이지에서 뒤로가기 시 주문 목록으로 이동 확인

## 병합 전 체크리스트

- [x] 수정 내용에 오타나 컨벤션이 틀린 부분이 없는지 확인했나요?
- [x] 추가된 리뷰에 대해 모두 수정 및 재리뷰를 완료했나요?