### PR TITLE
🐛 Fix:  order api 수정 및 search param 받아서 조회되게 수정

### DIFF
--- a/src/api/useGetOrders.ts
+++ b/src/api/useGetOrders.ts
@@ -22,17 +22,17 @@ export interface OrdersList {
   }
 }
 
-const useGetOrders = () => {
+const useGetOrders = (searchParams?: string) => {
   const qc = useQueryClient()
 
   const { data: orders, isSuccess } = useQuery({
-    queryKey: ['orders'],
+    queryKey: ['orders', searchParams],
     queryFn: async () => {
       const params: Record<string, string> = {}
 
       params.page = ''
       params.size = ''
-      params.keyword = ''
+      params.keyword = searchParams ?? ''
 
       return await api.get<Orders>(`orders`, {
         searchParams: params,

--- a/src/api/useGetOrdersDetail.ts
+++ b/src/api/useGetOrdersDetail.ts
@@ -53,10 +53,8 @@ const useGetOrdersDetail = (orderId?: string) => {
   const qc = useQueryClient()
 
   const { data: ordersDetail, isSuccess } = useQuery({
-    queryKey: ['ordersDetail'],
+    queryKey: ['ordersDetail', orderId],
     queryFn: async () => {
-
-
       return await api.get<OrdersDetail>(`orders/${orderId}`)
     },
   })

--- a/src/app/orders/_components/Order.tsx
+++ b/src/app/orders/_components/Order.tsx
@@ -3,18 +3,23 @@
 import OrderSearch from '@/app/orders/_components/OrderSearch'
 import OrderItem from '@/app/orders/_components/OrderItem'
 import Separator from '@/components/Separator'
-import useGetOrders, { Orders, OrdersList } from '@/api/useGetOrders'
+import useGetOrders from '@/api/useGetOrders'
 import { v4 as uuidv4 } from 'uuid'
-import React from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 
 const Order = () => {
-  const { orders, resetGetOrders, isSuccess } = useGetOrders()
+  const [searchValue, setSearchValue] = useState<string>('')
+  const { orders, resetGetOrders, isSuccess } = useGetOrders(searchValue)
+
+  const handelSearch = useCallback((value: string) => {
+    setSearchValue(value)
+  }, [])
 
   return (
     <>
       <div className="flex flex-col gap-10 pt-5">
         <div className="px-mobile_safe">
-          <OrderSearch />
+          <OrderSearch onSearch={handelSearch} />
         </div>
         <div className="mb-10 flex flex-1 flex-col gap-10 overflow-y-auto px-mobile_safe">
           {orders?.content.map((order) => (

--- a/src/app/orders/_components/OrderSearch.tsx
+++ b/src/app/orders/_components/OrderSearch.tsx
@@ -2,10 +2,18 @@
 
 import Icon from '@/components/Icon'
 import Input from '@/components/Input'
-import { useState } from 'react'
+import React, { useState } from 'react'
 
-const OrderSearch = () => {
+interface OrderSearchProps {
+  onSearch: (searchValue: string) => void
+}
+
+const OrderSearch: React.FC<OrderSearchProps> = ({ onSearch }) => {
   const [word, setWord] = useState('')
+
+  const handleSearch = () => {
+    onSearch(word)
+  }
 
   return (
     <div className="flex w-full flex-col gap-7">
@@ -18,6 +26,11 @@ const OrderSearch = () => {
           onReset={() => setWord('')}
           icon={<Icon name="Search" size={18} />}
           offOutline
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              handleSearch()
+            }
+          }}
         />
       </div>
     </div>


### PR DESCRIPTION
## 작업 내용

> 사진, 코드 등 리뷰어가 쉽게 이해할수 있게 상세히 리뷰어에 입장에서 작성해주요.
> 

1. order , order detail api 호출 시 캐싱으로 불러오던 값들을 queryKey에서 변경된 값에 따라 api 호출이 되도록 변경해주었습니다.
2. order api 호출 시 search Param를 넘겨주고 있지 않아 그 부분을 추가 수정했습니다. (현재  api에서 param를 받아도 모두 조회되어 수정 요청 드렸습니다.)

## 이러한 변경이 이루어지는 이유는 무엇인가요?

내용 

## 테스트 방법

> 변경사항에 대해 리뷰어가 테스트할 수 있는 가이드를 step by step으로 제공하세요.
> 
1. 내용

## 병합 전 체크리스트

- [ ]  수정 내용에 오타나 컨벤션이 틀린 부분이 없는지 확인했나요?
- [ ]  추가된 리뷰에 대해 모두 수정 및 재리뷰를 완료했나요?
