### PR TITLE
로그인, 회원가입 버그 수정 및 ky에러 처리 로직 추가

### DIFF
--- a/src/api/usePostLogin.ts
+++ b/src/api/usePostLogin.ts
@@ -1,20 +1,21 @@
-import { useLocalStorage } from '@/hooks/useLocalStorage';
-import { api } from '@/lib/api';
-import { LoginData, LoginResponse } from '@/models/auth';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useLocalStorage } from '@/hooks/useLocalStorage'
+import { api } from '@/lib/api'
+import { LoginData, LoginResponse } from '@/models/auth'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 const usePostLogin = () => {
-    const queryClient = useQueryClient()
-    const accessToken = useLocalStorage('accessToken')
-    const refreshToken = useLocalStorage('refreshToken')
-    return useMutation({
-        mutationFn: async (loginData:LoginData) => await api.post<LoginResponse>(`auth/login`, loginData),
-        onSuccess: (data) => {
-            accessToken.setValue(data.accessToken)
-            refreshToken.setValue(data.refreshToken)
-            queryClient.invalidateQueries({ queryKey: ['member'] })
-        }
-    })
+  const queryClient = useQueryClient()
+  const accessToken = useLocalStorage('accessToken')
+  const refreshToken = useLocalStorage('refreshToken')
+  return useMutation({
+    mutationFn: async (loginData: LoginData) =>
+      await api.post<LoginResponse>(`auth/login`, loginData),
+    onSuccess: (data) => {
+      accessToken.setValue(data.accessToken)
+      refreshToken.setValue(data.refreshToken)
+      queryClient.invalidateQueries({ queryKey: ['member'] })
+    },
+  })
 }
 
 export default usePostLogin

--- a/src/components/shared/LoginModal.tsx
+++ b/src/components/shared/LoginModal.tsx
@@ -5,9 +5,9 @@ import Input from '@/components/Input'
 import Separator from '@/components/Separator'
 import SignupModal from '@/components/shared/SignupModal'
 import { useToast } from '@/hooks/useToast'
+import { ApiErrorResponse } from '@/lib/api'
 import { modalStore } from '@/store/modal'
 import memberStore from '@/store/user'
-import { HTTPError } from 'ky'
 import { useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 
@@ -61,12 +61,11 @@ const LoginForm = () => {
 
   const onSubmit = handleSubmit((formData) => {
     login(formData, {
-      onError: async (error: Error) => {
-        const httpError = error as HTTPError
-        const errorData = (await httpError.response?.json()) as { data: { error: string } }
+      onError: async (error) => {
+        const apiError = error as unknown as ApiErrorResponse
         toast({
           title: '로그인 실패',
-          description: errorData?.data.error || '로그인에 실패했습니다.',
+          description: apiError.message || '알 수 없는 이유로 로그인에 실패했습니다.',
           variant: 'destructive',
           position: 'center',
         })

--- a/src/components/shared/SignupModal.tsx
+++ b/src/components/shared/SignupModal.tsx
@@ -123,7 +123,10 @@ const SignupForm = () => {
 
   const handlePhoneChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const formattedNumber = formatPhoneNumber(e.target.value)
-    setValue('phone', formattedNumber)
+    setValue('phone', formattedNumber, {
+      shouldValidate: true, // 값이 변경될 때마다 유효성 검사하는 옵션
+      shouldDirty: true, // 사용자가 입력하는 값이라는 것을 알려주는 옵션
+    })
   }
 
   return (

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,7 +1,7 @@
 import type { Options } from 'ky'
 import { kyClient, mockClient } from './apiClient'
 
-interface ApiResponse<T> {  
+interface ApiResponse<T> {
   data: T
   status: number
   message: string
@@ -13,7 +13,9 @@ export const api = {
     return response.data
   },
   post: async <T>(endpoint: string, body: unknown, options?: Options): Promise<T> => {
-    const response = await kyClient.post(endpoint, { json: body, ...options }).json<ApiResponse<T>>()
+    const response = await kyClient
+      .post(endpoint, { json: body, ...options })
+      .json<ApiResponse<T>>()
     return response.data
   },
   put: async <T>(endpoint: string, body: unknown, options?: Options): Promise<T> => {
@@ -32,11 +34,15 @@ export const mockApi = {
     return response.data
   },
   post: async <T>(endpoint: string, body: unknown, options?: Options): Promise<T> => {
-    const response = await mockClient.post(endpoint, { json: body, ...options }).json<ApiResponse<T>>()
+    const response = await mockClient
+      .post(endpoint, { json: body, ...options })
+      .json<ApiResponse<T>>()
     return response.data
   },
   put: async <T>(endpoint: string, body: unknown, options?: Options): Promise<T> => {
-    const response = await mockClient.put(endpoint, { json: body, ...options }).json<ApiResponse<T>>()
+    const response = await mockClient
+      .put(endpoint, { json: body, ...options })
+      .json<ApiResponse<T>>()
     return response.data
   },
   delete: async <T>(endpoint: string, options?: Options): Promise<T> => {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { Options } from 'ky'
+import { HTTPError, type Options } from 'ky'
 import { kyClient, mockClient } from './apiClient'
 
 interface ApiResponse<T> {
@@ -7,46 +7,94 @@ interface ApiResponse<T> {
   message: string
 }
 
+export interface ApiErrorResponse {
+  data?: unknown
+  message: string
+  status: number
+}
+
 export const api = {
   get: async <T>(endpoint: string, options?: Options): Promise<T> => {
-    const response = await kyClient.get(endpoint, options).json<ApiResponse<T>>()
-    return response.data
+    try {
+      const response = await kyClient.get(endpoint, options).json<ApiResponse<T>>()
+      return response.data
+    } catch (error) {
+      return handleError(error)
+    }
   },
   post: async <T>(endpoint: string, body: unknown, options?: Options): Promise<T> => {
-    const response = await kyClient
-      .post(endpoint, { json: body, ...options })
-      .json<ApiResponse<T>>()
-    return response.data
+    try {
+      const response = await kyClient
+        .post(endpoint, { json: body, ...options })
+        .json<ApiResponse<T>>()
+      return response.data
+    } catch (error) {
+      return handleError(error)
+    }
   },
   put: async <T>(endpoint: string, body: unknown, options?: Options): Promise<T> => {
-    const response = await kyClient.put(endpoint, { json: body, ...options }).json<ApiResponse<T>>()
-    return response.data
+    try {
+      const response = await kyClient
+        .put(endpoint, { json: body, ...options })
+        .json<ApiResponse<T>>()
+      return response.data
+    } catch (error) {
+      return handleError(error)
+    }
   },
   delete: async <T>(endpoint: string, options?: Options): Promise<T> => {
-    const response = await kyClient.delete(endpoint, options).json<ApiResponse<T>>()
-    return response.data
+    try {
+      const response = await kyClient.delete(endpoint, options).json<ApiResponse<T>>()
+      return response.data
+    } catch (error) {
+      return handleError(error)
+    }
   },
 }
 
 export const mockApi = {
   get: async <T>(endpoint: string, options?: Options): Promise<T> => {
-    const response = await mockClient.get(endpoint, options).json<ApiResponse<T>>()
-    return response.data
+    try {
+      const response = await mockClient.get(endpoint, options).json<ApiResponse<T>>()
+      return response.data
+    } catch (error) {
+      return handleError(error)
+    }
   },
   post: async <T>(endpoint: string, body: unknown, options?: Options): Promise<T> => {
-    const response = await mockClient
-      .post(endpoint, { json: body, ...options })
-      .json<ApiResponse<T>>()
-    return response.data
+    try {
+      const response = await mockClient
+        .post(endpoint, { json: body, ...options })
+        .json<ApiResponse<T>>()
+      return response.data
+    } catch (error) {
+      return handleError(error)
+    }
   },
   put: async <T>(endpoint: string, body: unknown, options?: Options): Promise<T> => {
-    const response = await mockClient
-      .put(endpoint, { json: body, ...options })
-      .json<ApiResponse<T>>()
-    return response.data
+    try {
+      const response = await mockClient
+        .put(endpoint, { json: body, ...options })
+        .json<ApiResponse<T>>()
+      return response.data
+    } catch (error) {
+      return handleError(error)
+    }
   },
   delete: async <T>(endpoint: string, options?: Options): Promise<T> => {
-    const response = await mockClient.delete(endpoint, options).json<ApiResponse<T>>()
-    return response.data
+    try {
+      const response = await mockClient.delete(endpoint, options).json<ApiResponse<T>>()
+      return response.data
+    } catch (error) {
+      return handleError(error)
+    }
   },
+}
+
+const handleError = async (error: unknown): Promise<never> => {
+  if (error instanceof HTTPError) {
+    const errorResponse = (await error.response.json()) as ApiErrorResponse
+    throw errorResponse
+  }
+  throw error
 }

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -1,4 +1,4 @@
-import ky from 'ky';
+import ky from 'ky'
 
 export const kyClient = ky.create({
   prefixUrl: process.env.NEXT_PUBLIC_API_URL, // Base URL 설정
@@ -8,9 +8,9 @@ export const kyClient = ky.create({
       (request) => {
         const accessToken = localStorage.getItem('accessToken')
         if (accessToken) {
-            request.headers.set('Authorization', accessToken);
+          request.headers.set('Authorization', accessToken)
         }
-      },  
+      },
     ],
     afterResponse: [
       (_request, _options, response) => {
@@ -28,7 +28,8 @@ export const kyClient = ky.create({
 })
 
 export const mockClient = kyClient.extend({
-  prefixUrl: process.env.NODE_ENV === 'development' 
-    ? `http://localhost:3000/api/v1`
-    : process.env.NEXT_PUBLIC_API_URL,
+  prefixUrl:
+    process.env.NODE_ENV === 'development'
+      ? `http://localhost:3000/api/v1`
+      : process.env.NEXT_PUBLIC_API_URL,
 })


### PR DESCRIPTION
## 작업 내용

> 사진, 코드 등 리뷰어가 쉽게 이해할수 있게 상세히 리뷰어에 입장에서 작성해주요.
> 

### 1. 에러 처리 개선
- API 에러 응답을 위한 `ApiErrorResponse` 인터페이스 추가
- HTTP 에러 핸들링 로직 통합 및 개선

### 2. 회원가입 폼 기능 개선
- 전화번호 입력 시 실시간 유효성 검사 추가하여 다른 input들과 동일하게 작동하도록 수정

### 3. 로그인 실패 Toast 개선
- 로그인 실패 시 Toast내용이 정삭적으로 표시되도록 수정

## react-query에서 error response 값 사용 방법

- ky에서 에러 받으면 서버에서 보내준 값을 반환 하도록 했습니다.
그런데 react-query에서 error가 Error로 타입이 지정되어 있어서 서버가 보내준값중 status나 data를 사용하시면 이렇게 타입지정을 해주셔야 타입에러가 뜨지 않습니다!
![image](https://github.com/user-attachments/assets/ed597b39-a00a-4081-85a0-762d4b6d6698)
![image](https://github.com/user-attachments/assets/0a8e3a8e-ee39-4c34-90af-e70f25441156)
- 그냥 message 사용시에는 Error에도 메세지가 있어서 그냥 사용해도 됩니다.
![image](https://github.com/user-attachments/assets/ae10b0d2-2f23-4bc9-9ae4-721eba89b170)



## 이러한 변경이 이루어지는 이유는 무엇인가요?

- 서버에서 보내준 error 결과값을 사용하기 위해서
- 회원가입시 다른 input과 동일한 동작을 보장하기 위해서 

## 테스트 방법

> 변경사항에 대해 리뷰어가 테스트할 수 있는 가이드를 step by step으로 제공하세요.
> 
- [ ] 로그인 실패 시 적절한 에러 메시지 표시
- [ ] 회원가입 시 전화번호 실시간 유효성 검사 동작 확인

## 병합 전 체크리스트

- [ ]  수정 내용에 오타나 컨벤션이 틀린 부분이 없는지 확인했나요?
- [ ]  추가된 리뷰에 대해 모두 수정 및 재리뷰를 완료했나요?
