### PR TITLE
토큰 자동 갱신 로직 구현

### DIFF
--- a/src/api/usePostLogin.ts
+++ b/src/api/usePostLogin.ts
@@ -1,20 +1,21 @@
-import { useLocalStorage } from '@/hooks/useLocalStorage';
-import { api } from '@/lib/api';
-import { LoginData, LoginResponse } from '@/models/auth';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useLocalStorage } from '@/hooks/useLocalStorage'
+import { api } from '@/lib/api'
+import { LoginData, LoginResponse } from '@/models/auth'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 const usePostLogin = () => {
-    const queryClient = useQueryClient()
-    const accessToken = useLocalStorage('accessToken')
-    const refreshToken = useLocalStorage('refreshToken')
-    return useMutation({
-        mutationFn: async (loginData:LoginData) => await api.post<LoginResponse>(`auth/login`, loginData),
-        onSuccess: (data) => {
-            accessToken.setValue(data.accessToken)
-            refreshToken.setValue(data.refreshToken)
-            queryClient.invalidateQueries({ queryKey: ['member'] })
-        }
-    })
+  const queryClient = useQueryClient()
+  const accessToken = useLocalStorage('accessToken')
+  const refreshToken = useLocalStorage('refreshToken')
+  return useMutation({
+    mutationFn: async (loginData: LoginData) =>
+      await api.post<LoginResponse>(`auth/login`, loginData),
+    onSuccess: (data) => {
+      accessToken.setValue(data.accessToken)
+      refreshToken.setValue(data.refreshToken)
+      queryClient.invalidateQueries({ queryKey: ['member'] })
+    },
+  })
 }
 
 export default usePostLogin

--- a/src/components/shared/LoginModal.tsx
+++ b/src/components/shared/LoginModal.tsx
@@ -5,9 +5,9 @@ import Input from '@/components/Input'
 import Separator from '@/components/Separator'
 import SignupModal from '@/components/shared/SignupModal'
 import { useToast } from '@/hooks/useToast'
+import { ApiErrorResponse } from '@/lib/api'
 import { modalStore } from '@/store/modal'
 import memberStore from '@/store/user'
-import { HTTPError } from 'ky'
 import { useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 
@@ -61,12 +61,11 @@ const LoginForm = () => {
 
   const onSubmit = handleSubmit((formData) => {
     login(formData, {
-      onError: async (error: Error) => {
-        const httpError = error as HTTPError
-        const errorData = (await httpError.response?.json()) as { data: { error: string } }
+      onError: async (error) => {
+        const apiError = error as unknown as ApiErrorResponse
         toast({
           title: '로그인 실패',
-          description: errorData?.data.error || '로그인에 실패했습니다.',
+          description: apiError.message || '알 수 없는 이유로 로그인에 실패했습니다.',
           variant: 'destructive',
           position: 'center',
         })

--- a/src/components/shared/SignupModal.tsx
+++ b/src/components/shared/SignupModal.tsx
@@ -123,7 +123,10 @@ const SignupForm = () => {
 
   const handlePhoneChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const formattedNumber = formatPhoneNumber(e.target.value)
-    setValue('phone', formattedNumber)
+    setValue('phone', formattedNumber, {
+      shouldValidate: true, // 값이 변경될 때마다 유효성 검사하는 옵션
+      shouldDirty: true, // 사용자가 입력하는 값이라는 것을 알려주는 옵션
+    })
   }
 
   return (

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,7 +1,7 @@
 import type { Options } from 'ky'
 import { kyClient, mockClient } from './apiClient'
 
-interface ApiResponse<T> {  
+interface ApiResponse<T> {
   data: T
   status: number
   message: string
@@ -13,7 +13,9 @@ export const api = {
     return response.data
   },
   post: async <T>(endpoint: string, body: unknown, options?: Options): Promise<T> => {
-    const response = await kyClient.post(endpoint, { json: body, ...options }).json<ApiResponse<T>>()
+    const response = await kyClient
+      .post(endpoint, { json: body, ...options })
+      .json<ApiResponse<T>>()
     return response.data
   },
   put: async <T>(endpoint: string, body: unknown, options?: Options): Promise<T> => {
@@ -32,11 +34,15 @@ export const mockApi = {
     return response.data
   },
   post: async <T>(endpoint: string, body: unknown, options?: Options): Promise<T> => {
-    const response = await mockClient.post(endpoint, { json: body, ...options }).json<ApiResponse<T>>()
+    const response = await mockClient
+      .post(endpoint, { json: body, ...options })
+      .json<ApiResponse<T>>()
     return response.data
   },
   put: async <T>(endpoint: string, body: unknown, options?: Options): Promise<T> => {
-    const response = await mockClient.put(endpoint, { json: body, ...options }).json<ApiResponse<T>>()
+    const response = await mockClient
+      .put(endpoint, { json: body, ...options })
+      .json<ApiResponse<T>>()
     return response.data
   },
   delete: async <T>(endpoint: string, options?: Options): Promise<T> => {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { Options } from 'ky'
+import { HTTPError, type Options } from 'ky'
 import { kyClient, mockClient } from './apiClient'
 
 interface ApiResponse<T> {
@@ -7,46 +7,94 @@ interface ApiResponse<T> {
   message: string
 }
 
+export interface ApiErrorResponse {
+  data?: unknown
+  message: string
+  status: number
+}
+
 export const api = {
   get: async <T>(endpoint: string, options?: Options): Promise<T> => {
-    const response = await kyClient.get(endpoint, options).json<ApiResponse<T>>()
-    return response.data
+    try {
+      const response = await kyClient.get(endpoint, options).json<ApiResponse<T>>()
+      return response.data
+    } catch (error) {
+      return handleError(error)
+    }
   },
   post: async <T>(endpoint: string, body: unknown, options?: Options): Promise<T> => {
-    const response = await kyClient
-      .post(endpoint, { json: body, ...options })
-      .json<ApiResponse<T>>()
-    return response.data
+    try {
+      const response = await kyClient
+        .post(endpoint, { json: body, ...options })
+        .json<ApiResponse<T>>()
+      return response.data
+    } catch (error) {
+      return handleError(error)
+    }
   },
   put: async <T>(endpoint: string, body: unknown, options?: Options): Promise<T> => {
-    const response = await kyClient.put(endpoint, { json: body, ...options }).json<ApiResponse<T>>()
-    return response.data
+    try {
+      const response = await kyClient
+        .put(endpoint, { json: body, ...options })
+        .json<ApiResponse<T>>()
+      return response.data
+    } catch (error) {
+      return handleError(error)
+    }
   },
   delete: async <T>(endpoint: string, options?: Options): Promise<T> => {
-    const response = await kyClient.delete(endpoint, options).json<ApiResponse<T>>()
-    return response.data
+    try {
+      const response = await kyClient.delete(endpoint, options).json<ApiResponse<T>>()
+      return response.data
+    } catch (error) {
+      return handleError(error)
+    }
   },
 }
 
 export const mockApi = {
   get: async <T>(endpoint: string, options?: Options): Promise<T> => {
-    const response = await mockClient.get(endpoint, options).json<ApiResponse<T>>()
-    return response.data
+    try {
+      const response = await mockClient.get(endpoint, options).json<ApiResponse<T>>()
+      return response.data
+    } catch (error) {
+      return handleError(error)
+    }
   },
   post: async <T>(endpoint: string, body: unknown, options?: Options): Promise<T> => {
-    const response = await mockClient
-      .post(endpoint, { json: body, ...options })
-      .json<ApiResponse<T>>()
-    return response.data
+    try {
+      const response = await mockClient
+        .post(endpoint, { json: body, ...options })
+        .json<ApiResponse<T>>()
+      return response.data
+    } catch (error) {
+      return handleError(error)
+    }
   },
   put: async <T>(endpoint: string, body: unknown, options?: Options): Promise<T> => {
-    const response = await mockClient
-      .put(endpoint, { json: body, ...options })
-      .json<ApiResponse<T>>()
-    return response.data
+    try {
+      const response = await mockClient
+        .put(endpoint, { json: body, ...options })
+        .json<ApiResponse<T>>()
+      return response.data
+    } catch (error) {
+      return handleError(error)
+    }
   },
   delete: async <T>(endpoint: string, options?: Options): Promise<T> => {
-    const response = await mockClient.delete(endpoint, options).json<ApiResponse<T>>()
-    return response.data
+    try {
+      const response = await mockClient.delete(endpoint, options).json<ApiResponse<T>>()
+      return response.data
+    } catch (error) {
+      return handleError(error)
+    }
   },
+}
+
+const handleError = async (error: unknown): Promise<never> => {
+  if (error instanceof HTTPError) {
+    const errorResponse = (await error.response.json()) as ApiErrorResponse
+    throw errorResponse
+  }
+  throw error
 }

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -1,4 +1,11 @@
+import { RefreshResponse } from '@/models/auth'
 import ky from 'ky'
+
+// 리프레시 토큰용 별도 클라이언트 생성
+const refreshClient = ky.create({
+  prefixUrl: process.env.NEXT_PUBLIC_API_URL,
+  timeout: 10000,
+})
 
 export const kyClient = ky.create({
   prefixUrl: process.env.NEXT_PUBLIC_API_URL, // Base URL 설정
@@ -13,17 +20,46 @@ export const kyClient = ky.create({
       },
     ],
     afterResponse: [
-      (_request, _options, response) => {
-        // 예: 로깅 처리
-        console.log(`Response: ${response.status} ${response.url}`)
+      async (request, options, response) => {
+        if (response.status === 511) {
+          console.log('토큰 만료 감지, 리프레시 토큰 요청 시작')
+
+          const accessToken = localStorage.getItem('accessToken')
+          const refreshToken = localStorage.getItem('refreshToken')
+
+          try {
+            // refreshClient를 사용하여 리프레시 토큰 요청
+            const response = await refreshClient
+              .post('auth/refresh', {
+                headers: {
+                  'Content-Type': 'application/json',
+                },
+                json: { accessToken, refreshToken },
+              })
+              .json<RefreshResponse>()
+
+            // 새로운 액세스 토큰 저장
+            localStorage.setItem('accessToken', response.data.accessToken)
+            localStorage.setItem('refreshToken', response.data.refreshToken)
+
+            // 원래 요청을 새 토큰으로 재시도
+            return ky(request, {
+              ...options,
+              headers: {
+                ...options.headers,
+                Authorization: response.data.accessToken,
+              },
+            })
+          } catch (error) {
+            console.error('리프레시 토큰 갱신 실패:', error)
+            // 로컬 스토리지의 토큰 제거
+            localStorage.removeItem('accessToken')
+            localStorage.removeItem('refreshToken')
+            throw new Error('리프레시 토큰 만료')
+          }
+        }
       },
     ],
-    // beforeError: [
-    //   (error) => {
-    //     console.error(error.message)
-    //     return error
-    //   },
-    // ],
   },
 })
 

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -1,4 +1,4 @@
-import ky from 'ky';
+import ky from 'ky'
 
 export const kyClient = ky.create({
   prefixUrl: process.env.NEXT_PUBLIC_API_URL, // Base URL 설정
@@ -8,9 +8,9 @@ export const kyClient = ky.create({
       (request) => {
         const accessToken = localStorage.getItem('accessToken')
         if (accessToken) {
-            request.headers.set('Authorization', accessToken);
+          request.headers.set('Authorization', accessToken)
         }
-      },  
+      },
     ],
     afterResponse: [
       (_request, _options, response) => {
@@ -28,7 +28,8 @@ export const kyClient = ky.create({
 })
 
 export const mockClient = kyClient.extend({
-  prefixUrl: process.env.NODE_ENV === 'development' 
-    ? `http://localhost:3000/api/v1`
-    : process.env.NEXT_PUBLIC_API_URL,
+  prefixUrl:
+    process.env.NODE_ENV === 'development'
+      ? `http://localhost:3000/api/v1`
+      : process.env.NEXT_PUBLIC_API_URL,
 })

--- a/src/models/auth.ts
+++ b/src/models/auth.ts
@@ -18,6 +18,13 @@ export interface LoginResponse {
   refreshTokenExpiresIn: string
 }
 
+export interface RefreshResponse {
+  data: {
+    accessToken: string
+    refreshToken: string
+  }
+}
+
 export interface Member {
   id: number
   signname: string


### PR DESCRIPTION
## 작업 내용

> 사진, 코드 등 리뷰어가 쉽게 이해할수 있게 상세히 리뷰어에 입장에서 작성해주요.
> 

### 토큰 자동 갱신 로직 구현
- 만료된 토큰 감지 시 리프레시 토큰으로 자동 재인증
- 새로운 액세스 토큰 및 리프레시 토큰 저장
- 토큰 갱신 실패 시 로컬 스토리지 토큰 제거

## 이러한 변경이 이루어지는 이유는 무엇인가요?

- 토큰 만료시 재발급을 자동으로 하기 위해서 

## 테스트 방법

> 변경사항에 대해 리뷰어가 테스트할 수 있는 가이드를 step by step으로 제공하세요.
> 
1. 로그인을 한다.
2. 로컬스토리지에 accesToken의 값을 변경한다.
3. refresh api 잘 호출되고 토큰이 갱신되는지 확인하다.

## 병합 전 체크리스트

- [ ]  수정 내용에 오타나 컨벤션이 틀린 부분이 없는지 확인했나요?
- [ ]  추가된 리뷰에 대해 모두 수정 및 재리뷰를 완료했나요?
