### PR TITLE
토큰 자동 갱신 로직 구현

### DIFF
--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -1,4 +1,11 @@
-import ky from 'ky';
+import { RefreshResponse } from '@/models/auth'
+import ky from 'ky'
+
+// 리프레시 토큰용 별도 클라이언트 생성
+const refreshClient = ky.create({
+  prefixUrl: process.env.NEXT_PUBLIC_API_URL,
+  timeout: 10000,
+})
 
 export const kyClient = ky.create({
   prefixUrl: process.env.NEXT_PUBLIC_API_URL, // Base URL 설정
@@ -8,27 +15,57 @@ export const kyClient = ky.create({
       (request) => {
         const accessToken = localStorage.getItem('accessToken')
         if (accessToken) {
-            request.headers.set('Authorization', accessToken);
+          request.headers.set('Authorization', accessToken)
         }
-      },  
-    ],
-    afterResponse: [
-      (_request, _options, response) => {
-        // 예: 로깅 처리
-        console.log(`Response: ${response.status} ${response.url}`)
       },
     ],
-    // beforeError: [
-    //   (error) => {
-    //     console.error(error.message)
-    //     return error
-    //   },
-    // ],
+    afterResponse: [
+      async (request, options, response) => {
+        if (response.status === 511) {
+          console.log('토큰 만료 감지, 리프레시 토큰 요청 시작')
+
+          const accessToken = localStorage.getItem('accessToken')
+          const refreshToken = localStorage.getItem('refreshToken')
+
+          try {
+            // refreshClient를 사용하여 리프레시 토큰 요청
+            const response = await refreshClient
+              .post('auth/refresh', {
+                headers: {
+                  'Content-Type': 'application/json',
+                },
+                json: { accessToken, refreshToken },
+              })
+              .json<RefreshResponse>()
+
+            // 새로운 액세스 토큰 저장
+            localStorage.setItem('accessToken', response.data.accessToken)
+            localStorage.setItem('refreshToken', response.data.refreshToken)
+
+            // 원래 요청을 새 토큰으로 재시도
+            return ky(request, {
+              ...options,
+              headers: {
+                ...options.headers,
+                Authorization: response.data.accessToken,
+              },
+            })
+          } catch (error) {
+            console.error('리프레시 토큰 갱신 실패:', error)
+            // 로컬 스토리지의 토큰 제거
+            localStorage.removeItem('accessToken')
+            localStorage.removeItem('refreshToken')
+            throw new Error('리프레시 토큰 만료')
+          }
+        }
+      },
+    ],
   },
 })
 
 export const mockClient = kyClient.extend({
-  prefixUrl: process.env.NODE_ENV === 'development' 
-    ? `http://localhost:3000/api/v1`
-    : process.env.NEXT_PUBLIC_API_URL,
+  prefixUrl:
+    process.env.NODE_ENV === 'development'
+      ? `http://localhost:3000/api/v1`
+      : process.env.NEXT_PUBLIC_API_URL,
 })

--- a/src/models/auth.ts
+++ b/src/models/auth.ts
@@ -18,6 +18,13 @@ export interface LoginResponse {
   refreshTokenExpiresIn: string
 }
 
+export interface RefreshResponse {
+  data: {
+    accessToken: string
+    refreshToken: string
+  }
+}
+
 export interface Member {
   id: number
   signname: string


### PR DESCRIPTION
## 작업 내용

> 사진, 코드 등 리뷰어가 쉽게 이해할수 있게 상세히 리뷰어에 입장에서 작성해주요.
> 

### 토큰 자동 갱신 로직 구현
- 만료된 토큰 감지 시 리프레시 토큰으로 자동 재인증
- 새로운 액세스 토큰 및 리프레시 토큰 저장
- 토큰 갱신 실패 시 로컬 스토리지 토큰 제거

## 이러한 변경이 이루어지는 이유는 무엇인가요?

- 토큰 만료시 재발급을 자동으로 하기 위해서 

## 테스트 방법

> 변경사항에 대해 리뷰어가 테스트할 수 있는 가이드를 step by step으로 제공하세요.
> 
1. 로그인을 한다.
2. 로컬스토리지에 accesToken의 값을 변경한다.
3. refresh api 잘 호출되고 토큰이 갱신되는지 확인하다.

## 병합 전 체크리스트

- [ ]  수정 내용에 오타나 컨벤션이 틀린 부분이 없는지 확인했나요?
- [ ]  추가된 리뷰에 대해 모두 수정 및 재리뷰를 완료했나요?
