### PR TITLE
회원가입 api 주소변경

### DIFF
--- a/src/api/usePostSignup.ts
+++ b/src/api/usePostSignup.ts
@@ -1,11 +1,11 @@
-import { api } from '@/lib/api';
-import { SignupData } from '@/models/auth';
-import { useMutation } from '@tanstack/react-query';
+import { api } from '@/lib/api'
+import { SignupData } from '@/models/auth'
+import { useMutation } from '@tanstack/react-query'
 
 const usePostSignup = () => {
-    return useMutation({
-        mutationFn: async (signupData:SignupData) => await api.post(`members/join`, signupData),
-    })
+  return useMutation({
+    mutationFn: async (signupData: SignupData) => await api.post(`auth/join`, signupData),
+  })
 }
 
 export default usePostSignup

--- a/src/components/shared/SignupModal.tsx
+++ b/src/components/shared/SignupModal.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/button'
 import Icon from '@/components/Icon'
 import Input from '@/components/Input'
 import { useToast } from '@/hooks/useToast'
+import { ApiErrorResponse } from '@/lib/api'
 import { formatPhoneNumber, unformatPhoneNumber } from '@/lib/format'
 import { modalStore } from '@/store/modal'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -107,9 +108,9 @@ const SignupForm = () => {
           description: '로그인을 진행해주세요.',
         })
       },
-      onError: (error: any) => {
-        const response = error.response
-        if (response.status === 400) {
+      onError: (error) => {
+        const errorResponse = error as unknown as ApiErrorResponse
+        if (errorResponse.status === 400) {
           toast({
             title: '회원가입에 실패했습니다.',
             description: (

--- a/src/components/shared/SignupModal.tsx
+++ b/src/components/shared/SignupModal.tsx
@@ -89,6 +89,15 @@ const SignupForm = () => {
     const processedFormData = {
       ...formData,
       phone: unformatPhoneNumber(formData.phone),
+      address: {
+        memberAddressType: 'HOME',
+        roadAddress: '도로명주소(집)',
+        jibunAddress: '지번주소(집)',
+        detailAddress: '',
+        alias: '',
+        latitude: 0.01,
+        longitude: 0.01,
+      },
     }
     signup(processedFormData, {
       onSuccess: () => {

--- a/src/models/auth.ts
+++ b/src/models/auth.ts
@@ -4,6 +4,15 @@ export interface SignupData {
   nickname: string
   username: string
   phone: string
+  address: {
+    memberAddressType: string
+    roadAddress: string
+    jibunAddress: string
+    detailAddress: string
+    alias: string
+    latitude: number
+    longitude: number
+  }
 }
 
 export interface LoginData {


### PR DESCRIPTION
## 작업 내용

> 사진, 코드 등 리뷰어가 쉽게 이해할수 있게 상세히 리뷰어에 입장에서 작성해주요.
> 

1. API 엔드포인트 수정
  members/join → auth/join으로 변경
2. 회원가입 데이터에 주소 추가
  임시 고정값 입력 (버그 바운티 때문에)


## 이러한 변경이 이루어지는 이유는 무엇인가요?

내용 

## 테스트 방법

> 변경사항에 대해 리뷰어가 테스트할 수 있는 가이드를 step by step으로 제공하세요.
> 
1. 내용

## 병합 전 체크리스트

- [ ]  수정 내용에 오타나 컨벤션이 틀린 부분이 없는지 확인했나요?
- [ ]  추가된 리뷰에 대해 모두 수정 및 재리뷰를 완료했나요?
