### PR TITLE
feat: 찜 기능 추가

### DIFF
--- a/src/api/useGetCarts.ts
+++ b/src/api/useGetCarts.ts
@@ -24,12 +24,12 @@ export interface Cart {
 
 const useGetCarts = () => {
   const qc = useQueryClient()
-  const {storedValue: accessToken} = useLocalStorage<String>("accessToken")
+  const { storedValue: accessToken } = useLocalStorage<string>('accessToken')
 
   const { data: carts } = useQuery({
     queryKey: ['carts'],
     queryFn: async () => await api.get<Cart>(`carts`, {}),
-    enabled: accessToken !== undefined,  // TODO: 로그인 한 경우에만 호출되도록
+    enabled: accessToken !== undefined, // TODO: 로그인 한 경우에만 호출되도록
   })
 
   const resetCarts = () => {

--- a/src/api/useGetFavorites.tsx
+++ b/src/api/useGetFavorites.tsx
@@ -1,0 +1,24 @@
+import { useLocalStorage } from '@/hooks/useLocalStorage'
+import { api } from '@/lib/api'
+import { useQuery } from '@tanstack/react-query'
+
+export interface Favorites {
+    id: string
+    name: string
+    imageMain: string
+    rating: number
+    reviewCount: number
+    minimumOrderAmount: number
+}
+
+const useGetFavorites = () => {
+    const { storedValue: accessToken } = useLocalStorage<string>('accessToken')
+
+    return useQuery({
+        queryKey: ['favorites'],
+        queryFn: async () => await api.get<Favorites[]>('favorites'),
+        enabled: accessToken !== undefined,
+    })
+}
+
+export default useGetFavorites

--- a/src/api/useGetOrders.ts
+++ b/src/api/useGetOrders.ts
@@ -1,3 +1,4 @@
+import { useLocalStorage } from '@/hooks/useLocalStorage'
 import { api } from '@/lib/api'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 
@@ -24,6 +25,7 @@ export interface OrdersList {
 
 const useGetOrders = (searchParams?: string) => {
   const qc = useQueryClient()
+  const { storedValue: accessToken } = useLocalStorage<string>('accessToken')
 
   const { data: orders, isSuccess } = useQuery({
     queryKey: ['orders', searchParams],
@@ -38,6 +40,7 @@ const useGetOrders = (searchParams?: string) => {
         searchParams: params,
       })
     },
+    enabled: !!accessToken,
   })
 
   const resetGetOrders = () => {

--- a/src/api/useGetRecentStores.tsx
+++ b/src/api/useGetRecentStores.tsx
@@ -1,0 +1,21 @@
+'use client'
+import { useLocalStorage } from '@/hooks/useLocalStorage'
+import { api } from '@/lib/api'
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
+import { Favorites } from './useGetFavorites'
+
+const useGetRecentStores = () => {
+    const { storedValue: recentStoreIds } = useLocalStorage<string[]>('recentStore', [])
+
+    return useQuery({
+        queryKey: ['recentStores', recentStoreIds],
+        queryFn: async () =>
+            await api.get<Favorites[]>('favorites/recent', {
+                searchParams: { storeIds: recentStoreIds ? recentStoreIds.join(',') : '' },
+            }),
+        enabled: !!recentStoreIds,
+        placeholderData: keepPreviousData,
+    })
+}
+
+export default useGetRecentStores

--- a/src/api/useGetStoreDetail.ts
+++ b/src/api/useGetStoreDetail.ts
@@ -18,11 +18,15 @@ interface StoreDetail {
   deliveryDistance: number
 }
 
-const useGetStoreDetail = (id: number | null) => {
+const useGetStoreDetail = (id: string | null) => {
   const qc = useQueryClient()
   const { coordinates: location } = useGeoLocationStore()
 
-  const { data: storeDetail, isSuccess } = useQuery({
+  const {
+    data: storeDetail,
+    isSuccess,
+    isError,
+  } = useQuery({
     enabled: Boolean(id && location && location.latitude && location.longitude),
     queryKey: ['storeDetail', id],
     queryFn: async () =>
@@ -38,7 +42,7 @@ const useGetStoreDetail = (id: number | null) => {
     qc.removeQueries({ queryKey: ['storeDetail', id] })
   }
 
-  return { storeDetail, resetStoreDetail, isSuccess }
+  return { storeDetail, resetStoreDetail, isSuccess, isError }
 }
 
 export default useGetStoreDetail

--- a/src/api/useGetStoreMenuCategory.ts
+++ b/src/api/useGetStoreMenuCategory.ts
@@ -1,24 +1,20 @@
-import { api } from '@/lib/api';
-import { MenuCategory } from '@/models/menu';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { api } from '@/lib/api'
+import { MenuCategory } from '@/models/menu'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 
-const useGetStoreMenuCategory = (id: number) => {
-    const qc = useQueryClient()
+const useGetStoreMenuCategory = (id: string) => {
+  const qc = useQueryClient()
 
-    const { data: storeMenuCategory, isSuccess } = useQuery({
-        queryKey: ['storeMenuCategory', id],
-        queryFn: async () => await api.get<MenuCategory[]>(`stores/${id}/menus`),
-      })
+  const { data: storeMenuCategory, isSuccess } = useQuery({
+    queryKey: ['storeMenuCategory', id],
+    queryFn: async () => await api.get<MenuCategory[]>(`stores/${id}/menus`),
+  })
 
-      const resetStoreMenuCategory = () => {
-        qc.removeQueries({ queryKey: ['storeMenuCategory', id] })
-      }
+  const resetStoreMenuCategory = () => {
+    qc.removeQueries({ queryKey: ['storeMenuCategory', id] })
+  }
 
-      return { storeMenuCategory, resetStoreMenuCategory, isSuccess }
+  return { storeMenuCategory, resetStoreMenuCategory, isSuccess }
 }
 
 export default useGetStoreMenuCategory
-
-
-
-

--- a/src/api/usePostFavorites.tsx
+++ b/src/api/usePostFavorites.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { useLocalStorage } from '@/hooks/useLocalStorage'
+import { api } from '@/lib/api'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+const usePostFavorites = () => {
+    const queryClient = useQueryClient()
+    const { storedValue: recentStoreIds, setValue } = useLocalStorage<string[]>('recentStore', [])
+
+    const { mutate: postFavorites } = useMutation({
+        mutationFn: async (storeId: string) => {
+            await api.post(`favorites/${storeId}`, {})
+
+            if (recentStoreIds) {
+                setValue(recentStoreIds.filter((id) => id !== storeId))
+            }
+        },
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['favorites'] })
+        },
+    })
+
+    const { mutate: deleteFavorites } = useMutation({
+        mutationFn: async (storeId: string) => {
+            await api.delete(`favorites/${storeId}`)
+        },
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['favorites'] })
+        },
+    })
+
+    return { postFavorites, deleteFavorites }
+}
+
+export default usePostFavorites

--- a/src/app/favorites/_components/Favorites.tsx
+++ b/src/app/favorites/_components/Favorites.tsx
@@ -1,16 +1,28 @@
 'use client'
 
-import FavoritesStoreList from "./FavoritesStoreList"
-import RecentStoreList from "./RecentStoreList"
-
+import LoginButtonSection from '@/components/shared/LoginButtonSection'
+import memberStore from '@/store/user'
+import FavoritesStoreList from './FavoritesStoreList'
+import RecentStoreList from './RecentStoreList'
 
 const Favorites = () => {
+    const { member } = memberStore()
+
     return (
-        <div className="bg-neutral-100 h-full">
-            <FavoritesStoreList />
-            <RecentStoreList />
-        </div>
-    )
+      <div className="flex h-full flex-col bg-neutral-100">
+          {member ? (
+              <FavoritesStoreList />
+          ) : (
+              <div className="px-mobile_safe pb-4 pt-[calc(20px+1rem)]">
+                  <LoginButtonSection
+                      text={`찜한 맛집을 확인하려면 로그인이 필요해요.\n 지금 가입하고 행복에 가까워지세요!`}
+                  />
+              </div>
+          )}
+
+          <RecentStoreList />
+      </div>
+  )
 }
 
 export default Favorites

--- a/src/app/favorites/_components/FavoritesListItem.tsx
+++ b/src/app/favorites/_components/FavoritesListItem.tsx
@@ -1,54 +1,91 @@
 'use client'
 
-import SampleImage from '@/assets/images/sample.jpg'
-import Dot from '@/components/Dot'
+import { Favorites } from '@/api/useGetFavorites'
+import usePostFavorites from '@/api/usePostFavorites'
 import Icon from '@/components/Icon'
-import { useToast } from '@/hooks/useToast'
+import { Skeleton } from '@/components/shadcn/skeleton'
+import { useLocalStorage } from '@/hooks/useLocalStorage'
 import { cn } from '@/lib/utils'
 import { COLORS } from '@/styles/color'
+import { ROUTE_PATHS } from '@/utils/routes'
 import Image from 'next/image'
+import { useRouter } from 'next/navigation'
 
 interface FavoritesListItemProps {
+    store: Favorites
     isRecent?: boolean
     isLast?: boolean
 }
 
-const FavoritesListItem = ({ isRecent, isLast }: FavoritesListItemProps) => {
-    const { toast } = useToast()
+const FavoritesListItem = ({ store, isRecent, isLast }: FavoritesListItemProps) => {
+    const router = useRouter()
+    const { deleteFavorites } = usePostFavorites()
+    const { storedValue: recentStoreIds, setValue } = useLocalStorage<string[]>('recentStore', [])
 
-    const handleClick = () => {
-        toast({
-            description: '준비중입니다.',
-            position: 'center'
-        })
+    const handleRecentStoreDelete = (e: React.MouseEvent<HTMLDivElement>) => {
+        e.stopPropagation()
+        if (!recentStoreIds) return
+
+        setValue(recentStoreIds.filter((id) => id !== store.id))
     }
 
+    const handleDelete = (e: React.MouseEvent<HTMLDivElement>) => {
+        e.stopPropagation()
+        deleteFavorites(store.id)
+    }
+
+    if (!store) return null
     return (
-        <div className={cn("flex gap-2 bg-white px-mobile_safe py-4 border-b border-solid", isLast ? 'border-b-0' : 'border-b-gray-200')} onClick={handleClick}>
-            <div className="relative w-[80px] h-[80px] rounded-md overflow-hidden">
-                <Image src={SampleImage} className='object-cover' alt="sample" fill />
-            </div>
-            <div className="flex flex-1 flex-col justify-center gap-1">
-                <p className="text-base text-black font-semibold">컴포즈커피-관악신사교차로점</p>
-                <div className="flex gap-1 items-center">
-                    <div className="flex gap-1 items-center text-xs text-gray-500">
-                        <div className="flex gap-[2px] items-center">
-                            <Icon name='Star' size={12} color={COLORS.primary} fill={COLORS.primary} />
-                            <span className="text-black font-bold">4.5</span>
-                        </div>
-                        <span>(9)</span>
-                    </div>
-                    <Dot />
-                    <span className="text-xs text-gray-500">포장가능</span>
-                </div>
-                <p className="text-sm text-gray-500">최소 주문 <span className="text-black font-medium">6,000원</span></p>
-            </div>
-            <div className={cn('flex flex-col gap-1', isRecent ? 'justify-between' : 'justify-center')}>
-                {isRecent && <Icon className='text-gray-600' name='X' size={22} />}
-                {isRecent ? <Icon className='mb-2' name='Heart' size={24} /> : <Icon name='Heart' size={24} color={COLORS.primary} fill={COLORS.primary} />}
-            </div>
-        </div>
-    )
+      <div
+          className={cn(
+              'flex gap-2 border-b border-solid bg-white px-mobile_safe py-4',
+              isLast ? 'border-b-0' : 'border-b-gray-200'
+          )}
+          onClick={() => router.push(`${ROUTE_PATHS.STORE_DETAIL}/${store.id}`)}
+      >
+          <div className="relative size-[80px] overflow-hidden rounded-md">
+              {store.imageMain ? (
+                  <Image src={store.imageMain} className="object-cover" alt="sample" fill sizes="80px" />
+              ) : (
+                  <Skeleton className="size-full" />
+              )}
+          </div>
+          <div className="flex flex-1 flex-col justify-center gap-1">
+              <p className="max-w-[calc(100dvw-40px-80px-1rem-22px)] truncate text-base font-semibold text-black">
+                  {store.name}
+              </p>
+              <div className="flex items-center gap-1">
+                  <div className="flex items-center gap-1 text-xs text-gray-500">
+                      <div className="flex items-center gap-[2px]">
+                          <Icon name="Star" size={12} color={COLORS.primary} fill={COLORS.primary} />
+                          <span className="font-bold text-black">{store.rating}</span>
+                      </div>
+                      <span>({store.reviewCount})</span>
+                  </div>
+                  {/* <Dot />
+                  <span className="text-xs text-gray-500">포장가능</span> */}
+              </div>
+              <p className="text-sm text-gray-500">
+                  최소 주문{' '}
+                  <span className="font-medium text-black">
+                      {store.minimumOrderAmount.toLocaleString()}원
+                  </span>
+              </p>
+          </div>
+          <div className={cn('flex flex-col gap-1', isRecent ? 'justify-between' : 'justify-center')}>
+              {isRecent ? (
+                  <Icon className="text-gray-600" name="X" size={22} onClick={handleRecentStoreDelete} />
+              ) : (
+                  <Icon
+                      className="fill-red-500 text-red-500"
+                      name="Heart"
+                      size={24}
+                      onClick={handleDelete}
+                  />
+              )}
+          </div>
+      </div>
+  )
 }
 
 export default FavoritesListItem

--- a/src/app/favorites/_components/FavoritesStoreList.tsx
+++ b/src/app/favorites/_components/FavoritesStoreList.tsx
@@ -1,30 +1,53 @@
-import FavoritesListItem from "./FavoritesListItem"
+'use client'
+
+import useGetFavorites from '@/api/useGetFavorites'
+import { ROUTE_PATHS } from '@/utils/routes'
+import { useRouter } from 'next/navigation'
+import FavoritesListItem from './FavoritesListItem'
 
 const FavoritesStoreList = () => {
+    const { data: favorites } = useGetFavorites()
+
     return (
         <div>
-            <p className="flex items-center gap-2 text-base text-black font-bold px-mobile_safe py-3">찜한 맛집 <span className="text-sm text-gray-500 font-medium">2개</span></p>
-            {new Array(2).fill(0).map((_, index) => (
-                <FavoritesListItem key={index} isLast={index === 1} />
-            ))}
-            {/* <EmptyFavorites /> */}
-        </div>
-    )
+          <p className="flex items-center gap-2 bg-neutral-100 px-mobile_safe py-3 text-base font-bold text-black">
+              찜한 맛집 <span className="text-sm font-medium text-gray-500">{favorites?.length}개</span>
+          </p>
+          {favorites && favorites.length > 0 ? (
+              favorites.map((_, index) => (
+                  <FavoritesListItem
+                      key={`${_.id}-${index}`}
+                      store={_}
+                      isLast={index === favorites.length - 1}
+                  />
+              ))
+          ) : (
+              <EmptyFavorites />
+          )}
+      </div>
+  )
 }
 
 const EmptyFavorites = () => {
+    const router = useRouter()
+
     return (
         <div className="px-mobile_safe">
-            <div className="bg-white px-mobile_safe rounded-md pt-7 pb-6">
-                <p className="text-center text-base text-gray-400 pb-4">
-                    즐겨찾는 맛집이 없어요. <br />
-                    좋아하는 맛집을 '찜'하고 <br />
-                    빠르게 찾아보세요.
-                </p>
-                <button className="w-full h-[44px] border border-solid border-gray-400 rounded-md px-4 py-2 text-gray-700">맛집 구경하러 가기</button>
-            </div>
-        </div>
-    )
+          <div className="rounded-md bg-white px-mobile_safe pb-6 pt-7">
+              <p className="pb-4 text-center text-base text-gray-400">
+                  즐겨찾는 맛집이 없어요. <br />
+                  좋아하는 맛집을 '찜'하고 <br />
+                  빠르게 찾아보세요.
+              </p>
+              <button
+                  className="h-[44px] w-full rounded-md border border-solid border-gray-400 px-4 py-2 text-gray-700"
+                  onClick={() => router.push(ROUTE_PATHS.HOME)}
+              >
+                  맛집 구경하러 가기
+              </button>
+          </div>
+      </div>
+  )
 }
 
 export default FavoritesStoreList

--- a/src/app/favorites/_components/RecentStoreList.tsx
+++ b/src/app/favorites/_components/RecentStoreList.tsx
@@ -1,21 +1,37 @@
-import FavoritesListItem from "./FavoritesListItem"
+import useGetRecentStores from '@/api/useGetRecentStores'
+import FavoritesListItem from './FavoritesListItem'
 
 const RecentStoreList = () => {
+    const { data: recentStores } = useGetRecentStores()
+
     return (
-        <div>
-            <p className="flex items-center gap-2 px-mobile_safe text-base text-black font-bold py-3">최근 본 맛집 <span className="text-sm text-gray-500 font-medium">1개</span></p>
-            <FavoritesListItem isRecent={true} isLast={true} />
-            {/* <EmptyRecentStore /> */}
-        </div>
-    )
+      <div className="flex flex-1 flex-col">
+          <p className="flex items-center gap-2 bg-neutral-100 px-mobile_safe py-3 text-base font-bold text-black">
+              최근 본 맛집{' '}
+              <span className="text-sm font-medium text-gray-500">{recentStores?.length}개</span>
+          </p>
+          {recentStores && recentStores.length > 0 ? (
+              recentStores.map((store, index) => (
+                  <FavoritesListItem
+                      key={store.id}
+                      store={store}
+                      isRecent={true}
+                      isLast={index === recentStores.length - 1}
+                  />
+              ))
+          ) : (
+              <EmptyRecentStore />
+          )}
+      </div>
+  )
 }
 
 const EmptyRecentStore = () => {
     return (
-        <div className="h-[400px] w-full flex justify-center items-center bg-white px-mobile_safe pt-7 pb-6">
-            <p className="text-base text-gray-700 pb-4">최근 방문한 맛집들을 볼 수 있어요.</p>
-        </div>
-    )
+      <div className="flex min-h-[112px] w-full flex-1 items-center justify-center bg-white px-mobile_safe pb-6 pt-7">
+          <p className="text-base text-gray-700">최근 방문한 맛집들을 볼 수 있어요.</p>
+      </div>
+  )
 }
 
 export default RecentStoreList

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,6 +14,13 @@ export const metadata: Metadata = {
   description: '개발의민족',
 }
 
+export const viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
+}
+
 export default function RootLayout({
   children,
 }: Readonly<{

--- a/src/app/orders/_components/Order.tsx
+++ b/src/app/orders/_components/Order.tsx
@@ -10,7 +10,7 @@ import { v4 as uuidv4 } from 'uuid'
 
 const Order = () => {
   const [searchValue, setSearchValue] = useState<string>('')
-  const { orders, resetGetOrders, isSuccess } = useGetOrders(searchValue)
+  const { orders } = useGetOrders(searchValue)
 
   const handelSearch = useCallback((value: string) => {
     setSearchValue(value)

--- a/src/app/orders/_components/OrderItem.tsx
+++ b/src/app/orders/_components/OrderItem.tsx
@@ -1,6 +1,7 @@
 import { OrdersList } from '@/api/useGetOrders'
 import Badge from '@/components/Badge'
 import { Button } from '@/components/button'
+import { Skeleton } from '@/components/shadcn/skeleton'
 import { ROUTE_PATHS } from '@/utils/routes'
 import Image from 'next/image'
 import Link from 'next/link'
@@ -9,14 +10,18 @@ const OrderItem = ({ order }: OrdersList) => {
   return (
     <div className="flex flex-col gap-5">
       <div className="flex flex-row">
-        <Image
-          className="size-[100px] rounded-xl object-cover object-center"
-          src={order.imageThumbnail}
-          alt="음식점 대표 이미지"
-          width={100}
-          height={100}
-          loading="lazy"
-        />
+        {order.imageThumbnail ? (
+          <Image
+            className="size-[100px] rounded-xl object-cover object-center"
+            src={order.imageThumbnail}
+            alt="음식점 대표 이미지"
+            width={100}
+            height={100}
+            loading="lazy"
+          />
+        ) : (
+          <Skeleton className="size-[100px] rounded-xl" />
+        )}
         <div className="flex w-[calc(100%-1rem-100px)] flex-col gap-4 pl-4">
           <div className="flex flex-row justify-between">
             <Badge variant="complete">{order.status.desc}</Badge>

--- a/src/app/store/detail/[id]/_components/StoreHeader.tsx
+++ b/src/app/store/detail/[id]/_components/StoreHeader.tsx
@@ -1,17 +1,25 @@
 'use client'
 
+import useGetFavorites from '@/api/useGetFavorites'
+import usePostFavorites from '@/api/usePostFavorites'
 import Icon from '@/components/Icon'
 import { Skeleton } from '@/components/shadcn/skeleton'
+import LoginModal from '@/components/shared/LoginModal'
+import { useLocalStorage } from '@/hooks/useLocalStorage'
 import { useToast } from '@/hooks/useToast'
 import { cn } from '@/lib/utils'
+import { modalStore } from '@/store/modal'
 import { orderDetailStore } from '@/store/orderDetail'
+import { ROUTE_PATHS } from '@/utils/routes'
 import { AnimatePresence, motion } from 'motion/react'
 import { useRouter } from 'next/navigation'
+import { useEffect } from 'react'
 
 interface StoreHeaderProps {
   isHeaderOpaque: boolean
   isSuccess: boolean
   title: string
+  storeId: string
   isOrderDetail?: boolean
 }
 
@@ -19,49 +27,134 @@ const StoreHeader = ({
   isHeaderOpaque,
   isSuccess,
   title,
+  storeId,
   isOrderDetail = false,
 }: StoreHeaderProps) => {
   const router = useRouter()
   const { hideOrderDetail } = orderDetailStore()
+  const { data: favorites, isSuccess: isFavoritesSuccess } = useGetFavorites()
+  const { postFavorites, deleteFavorites } = usePostFavorites()
+  const { setValue } = useLocalStorage<string[]>('recentStore', [])
+  const { storedValue: accessToken } = useLocalStorage('accessToken')
+  const { showModal } = modalStore()
+
   const { toast } = useToast()
 
-  const handleShare = async () => {
+  const copyToClipboard = (text: string) => {
+    // 임시 textarea 엘리먼트 생성
+    const textarea = document.createElement('textarea')
+    textarea.value = text
+    textarea.style.position = 'fixed'
+    textarea.style.left = '-9999px'
+    document.body.appendChild(textarea)
+
     try {
-      await navigator.clipboard.writeText(window.location.href)
+      // 텍스트 선택 및 복사
+      textarea.select()
+      document.execCommand('copy')
       toast({
         description: 'URL이 복사되었습니다.',
         position: 'center',
       })
-    } catch (error) {
+    } catch (err) {
+      console.error('클립보드 복사 실패:', err)
       toast({
         description: 'URL 복사에 실패했습니다.',
         position: 'center',
         variant: 'destructive',
       })
+    } finally {
+      // 임시 textarea 제거
+      document.body.removeChild(textarea)
     }
   }
+
+  const handleShare = async () => {
+    try {
+      if (!navigator.share) {
+        // Web Share API가 지원되지 않는 경우 클립보드 복사로 폴백
+        copyToClipboard(window.location.href)
+        return
+      }
+
+      await navigator.share({
+        title: title,
+        text: `${title} - O2O`,
+        url: window.location.href,
+      })
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        (error.name === 'AbortError' || error.name === 'InvalidStateError')
+      ) {
+        // 사용자가 공유를 취소한 경우 토스트를 표시하지 않음
+        return
+      }
+
+      copyToClipboard(window.location.href)
+    }
+  }
+
+  const handleFavorite = () => {
+    if (!accessToken) {
+      toast({
+        description: '로그인이 필요한 기능이에요.',
+        position: 'center',
+      })
+
+      showModal({ content: <LoginModal />, useAnimation: true })
+      return
+    }
+
+    if (favorites?.some((favorite) => favorite.id === storeId)) {
+      deleteFavorites(storeId)
+    } else {
+      postFavorites(storeId)
+    }
+  }
+
+  useEffect(() => {
+    if (isFavoritesSuccess) {
+      const recentStores = JSON.parse(localStorage.getItem('recentStore') || '[]')
+
+      if (!favorites?.some((favorite) => favorite.id === storeId)) {
+        // 현재 storeId를 제외한 기존 배열 생성
+        const filteredStores = recentStores.filter((id: string) => id !== storeId)
+        // 현재 storeId를 배열 맨 앞에 추가
+        setValue([storeId, ...filteredStores].slice(0, 10))
+      }
+    }
+  }, [isFavoritesSuccess])
 
   return (
     <div
       className={cn(
-        'fixed top-0 z-20 flex h-detail_header w-full min-w-[320px] max-w-[480px] items-center justify-between pt-2 transition-all duration-200',
-        isHeaderOpaque
-          ? 'border-b border-solid border-gray-200 bg-white px-[10px]'
-          : 'bg-transparent px-mobile_safe'
+        'fixed top-0 z-20 flex w-full min-w-[320px] max-w-[480px] items-center justify-between px-mobile_safe',
+        isHeaderOpaque ? 'border-b border-solid border-gray-200 bg-white' : 'bg-transparent'
       )}
     >
-      <div className="flex items-center gap-2">
+      <div className="mt-3 flex h-detail_header items-center gap-2">
         <button
-          className="flex size-8 items-center justify-center rounded-full bg-white"
+          className={cn(
+            'flex size-8 items-center justify-center rounded-full bg-white transition-all duration-200',
+            isHeaderOpaque && 'size-6'
+          )}
           onClick={() => {
             if (isOrderDetail) {
               hideOrderDetail()
             } else {
-              router.back()
+              const currentDomain = window.location.origin
+              const isPreviousPageSameDomain = document.referrer.startsWith(currentDomain)
+
+              if (window.history.length > 1 && isPreviousPageSameDomain) {
+                router.back()
+              } else {
+                router.push(ROUTE_PATHS.HOME)
+              }
             }
           }}
         >
-          <Icon name="ChevronLeft" size={22} />
+          <Icon name="ChevronLeft" size={24} />
         </button>
         <AnimatePresence>
           {isHeaderOpaque && (
@@ -70,36 +163,47 @@ const StoreHeader = ({
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
-              transition={{ duration: 0.1 }}
+              transition={{ duration: 0.2 }}
             >
               {!isSuccess ? <Skeleton className="h-[28px] w-[150px]" /> : title}
             </motion.span>
           )}
         </AnimatePresence>
       </div>
-      <div className="flex items-center gap-2">
+      <div className="mt-3 flex items-center gap-2">
         <button
-          className="flex size-8 items-center justify-center rounded-full bg-white"
+          className={cn(
+            'flex size-8 items-center justify-center rounded-full bg-white transition-all duration-200',
+            isHeaderOpaque && 'size-6'
+          )}
           onClick={handleShare}
         >
-          <Icon name="Share2" size={18} />
+          <Icon name="Share2" size={20} />
         </button>
         {!isOrderDetail && (
           <button
-            className="flex size-8 items-center justify-center rounded-full bg-white"
-            onClick={() => {
-              toast({
-                description: '준비중입니다.',
-                position: 'center',
-              })
-            }}
+            className={cn(
+              'flex size-8 items-center justify-center rounded-full bg-white transition-all duration-200',
+              isHeaderOpaque && 'size-6'
+            )}
+            onClick={handleFavorite}
           >
-            <Icon name="Heart" size={18} />
+            <Icon
+              className={cn(
+                favorites?.some((favorite) => favorite.id === storeId) &&
+                'fill-red-500 text-red-500'
+              )}
+              name="Heart"
+              size={20}
+            />
           </button>
         )}
         {!isOrderDetail && (
           <button
-            className="flex size-8 items-center justify-center rounded-full bg-white"
+            className={cn(
+              'flex size-8 items-center justify-center rounded-full bg-white transition-all duration-200',
+              isHeaderOpaque && 'size-6'
+            )}
             onClick={() => {
               toast({
                 description: '준비중입니다.',
@@ -107,7 +211,7 @@ const StoreHeader = ({
               })
             }}
           >
-            <Icon name="Search" size={18} />
+            <Icon name="Search" size={20} />
           </button>
         )}
       </div>

--- a/src/app/store/detail/[id]/page.tsx
+++ b/src/app/store/detail/[id]/page.tsx
@@ -6,7 +6,7 @@ const StoreDetailPage = async ({ params }: { params: Promise<{ id: string }> }) 
   if (!id) {
     return <div>스토어 아이디가 없습니다.</div>
   }
-  return <StoreDetail storeId={Number(id)} />
+  return <StoreDetail storeId={id} />
 }
 
 export default StoreDetailPage

--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -17,16 +17,16 @@ const Alert = ({ title, message, onClick, cancelText }: AlertProps) => {
     }
 
     return (
-        <div className='w-[70%] max-w-[440px] min-h-[150px] flex flex-col gap-6 bg-white rounded-xl p-5'>
-            <div className='flex flex-col flex-1 gap-2'>
-                <div className='text-lg font-bold text-center'>{title}</div>
-                <div className='text-base text-center'>{message}</div>
-            </div>
-            <div>
-                <Button onClick={handleClick}>{cancelText || '확인'}</Button>
-            </div>
-        </div>
-    )
+      <div className="flex min-h-[150px] w-[70%] max-w-[440px] flex-col gap-6 rounded-xl bg-white p-5">
+          <div className="flex flex-1 flex-col gap-2">
+              <div className="text-center text-lg font-bold">{title}</div>
+              <div className="text-center text-base">{message}</div>
+          </div>
+          <div>
+              <Button onClick={handleClick}>{cancelText || '확인'}</Button>
+          </div>
+      </div>
+  )
 }
 
 export default Alert

--- a/src/components/CommonLayout.tsx
+++ b/src/components/CommonLayout.tsx
@@ -46,8 +46,8 @@ const CommonLayout = ({ children }: CommonLayoutProps) => {
   const { storedValue: accessToken } = useLocalStorage('accessToken')
   const { data: memberData, isFetching, refetch } = useGetMember()
   const { mutate: logout } = usePostLogout()
-  const { member, setMember } = memberStore()
-  const { isGlobalLoading, setIsGlobalLoading } = globalLoaderStore()
+  const { setMember } = memberStore()
+  const { setIsGlobalLoading } = globalLoaderStore()
 
   useEffect(() => {
     if (accessToken) {
@@ -98,7 +98,6 @@ const CommonLayout = ({ children }: CommonLayoutProps) => {
                 latitude: position.coords.latitude,
                 longitude: position.coords.longitude,
               }
-              console.log({ coords })
               setCoordinatesState(coords)
               setCoordinates(coords)
               setIsLoading(false)

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -11,7 +11,7 @@ const inputVariants = cva('', {
   variants: {
     inputSize: {
       default: 'h-12 text-base',
-      sm: 'h-navigation text-sm',
+      sm: 'h-navigation text-base',
     },
     offOutline: {
       true: 'focus-visible:ring-0 focus-visible:ring-offset-0',
@@ -28,7 +28,7 @@ const labelVariants = cva('mb-1.5 block font-medium', {
   variants: {
     inputSize: {
       default: 'text-base',
-      sm: 'text-sm',
+      sm: 'text-base',
     },
   },
   defaultVariants: {
@@ -106,7 +106,7 @@ const Input = React.forwardRef<HTMLInputElement, CommonInputProps>(
               isInvalid && 'border-red-500 focus-visible:ring-red-500',
               props.value && type === 'password' && onReset && 'pr-20', // 패스워드 토글과 x 버튼 공간
               props.value && type === 'password' && !onReset && 'pr-14', // 패스워드 토글 공간만
-              props.value && type !== 'password' && onReset && 'pr-10', // x 버튼 공간만
+              props.value && type !== 'password' && onReset && 'pr-10' // x 버튼 공간만
             )}
             {...props}
           />
@@ -122,12 +122,7 @@ const Input = React.forwardRef<HTMLInputElement, CommonInputProps>(
               </button>
             )}
             {props.value && onReset && (
-              <button
-                type="button"
-                onClick={onReset}
-                className="z-10"
-                tabIndex={-1}
-              >
+              <button type="button" onClick={onReset} className="z-10" tabIndex={-1}>
                 <Icon
                   name="CircleX"
                   size={resetIconSizes[inputSize ?? 'default']}
@@ -141,7 +136,7 @@ const Input = React.forwardRef<HTMLInputElement, CommonInputProps>(
         </div>
       </div>
     )
-  },
+  }
 )
 
 Input.displayName = 'CommonInput'

--- a/src/components/shared/LoginButtonSection.tsx
+++ b/src/components/shared/LoginButtonSection.tsx
@@ -4,17 +4,17 @@ import { Button } from '@/components/button'
 import LoginModal from '@/components/shared/LoginModal'
 import { modalStore } from '@/store/modal'
 
-const LoginButtonSection = () => {
+const LoginButtonSection = ({ text }: { text?: string }) => {
   const { showModal } = modalStore()
 
   const handleOpenLoginModal = () => {
     showModal({ content: <LoginModal />, useAnimation: true })
   }
   return (
-    <section className="rounded-xl border border-solid border-gray-400 p-4 text-center">
+    <section className="rounded-xl border border-solid border-gray-400 bg-white p-4 text-center">
       <div className="mb-1 text-lg font-bold">개발의 민족에 오신 것을 환영합니다.</div>
       <div className="mb-4 whitespace-pre-line text-sm text-gray-500">
-        {`로그인 후 매일 맛있는 음식을 즐겨보세요.\n 지금 가입하고 행복에 가까워지세요!`}
+        {text || `로그인 후 매일 맛있는 음식을 즐겨보세요.\n 지금 가입하고 행복에 가까워지세요!`}
       </div>
       <Button className="inline-flex w-fit gap-0.5" onClick={handleOpenLoginModal}>
         <span>로그인</span>

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -31,7 +31,6 @@ export const useInfiniteScroll = <TData, TFilter = void>({
   rootMargin = '0px',
   location = { lat: 37.5177, lng: 127.0473 },
 }: InfiniteScrollOptions<TFilter>) => {
-  console.log({ location })
   const observerRef = useRef<IntersectionObserver | null>(null)
   const targetRef = useRef<HTMLDivElement | null>(null)
   const timeoutRef = useRef<NodeJS.Timeout | null>(null)

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -29,7 +29,7 @@ if (typeof window !== 'undefined') {
 
 export function useLocalStorage<T>(
   key: string,
-  initialValue: T | undefined = undefined,
+  initialValue: T | undefined = undefined
 ): {
   storedValue: T | undefined
   setValue: (value: T) => void
@@ -51,7 +51,8 @@ export function useLocalStorage<T>(
         }
 
         setStoredValue(valueToStore)
-        const stringifiedValue = typeof valueToStore === 'string' ? valueToStore : JSON.stringify(valueToStore)
+        const stringifiedValue =
+          typeof valueToStore === 'string' ? valueToStore : JSON.stringify(valueToStore)
         localStorage.setItem(key, stringifiedValue)
 
         // 같은 창에서의 변경사항도 감지하기 위한 커스텀 이벤트 발생
@@ -59,13 +60,13 @@ export function useLocalStorage<T>(
           new StorageEvent('storage', {
             key: key,
             newValue: stringifiedValue,
-          }),
+          })
         )
       } catch (error) {
         console.error('localStorage 저장 에러:', error)
       }
     },
-    [key],
+    [key]
   )
 
   const resetValue = useMemo(
@@ -73,7 +74,7 @@ export function useLocalStorage<T>(
       setStoredValue(initialValue)
       localStorage.removeItem(key)
     },
-    [key, initialValue],
+    [key, initialValue]
   )
 
   // 클라이언트 사이드에서만 localStorage 값을 읽어옴
@@ -82,6 +83,7 @@ export function useLocalStorage<T>(
 
     try {
       const item = localStorage.getItem(key)
+
       if (item) {
         try {
           // 첫 번째로 JSON 파싱을 시도

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -53,7 +53,7 @@ export default {
       },
       spacing: {
         mobile_safe: '20px',
-        detail_header: '50px',
+        detail_header: '40px',
       },
       height: {
         navigation: '40px',
@@ -89,13 +89,13 @@ export default {
             opacity: '0.8',
           },
         },
-        "fade-in": {
-          from: { opacity: "0" },
-          to: { opacity: "1" },
+        'fade-in': {
+          from: { opacity: '0' },
+          to: { opacity: '1' },
         },
-        "fade-out": {
-          from: { opacity: "1" },
-          to: { opacity: "0" },
+        'fade-out': {
+          from: { opacity: '1' },
+          to: { opacity: '0' },
         },
       },
       animation: {


### PR DESCRIPTION
## 작업 내용

가게 상세 페이지에 즐겨찾기 기능을 추가하였습니다.

### 주요 변경사항
1. 가게 상세 페이지 헤더에 즐겨찾기 버튼 추가 및 기능 구현
2. 즐겨찾기 API 연동 (추가/삭제)
3. 최근 본 가게 기능 추가 (localStorage 활용)
4. 가게 상세 페이지 UI/UX 개선
   - 헤더 스크롤 애니메이션 개선
   - 공유하기 기능 Web Share API 지원
   - 뒤로가기 로직 개선

### UI 변경사항
- 헤더의 아이콘 크기와 여백 조정
- 즐겨찾기된 가게는 하트 아이콘이 빨간색으로 표시
- 스크롤에 따른 헤더 크기 변경 애니메이션 추가

## 이러한 변경이 이루어지는 이유는 무엇인가요?

1. 사용자가 자주 방문하는 가게를 쉽게 찾을 수 있도록 즐겨찾기 기능 추가
2. 최근 본 가게 기록을 통해 사용자의 탐색 경험 개선
3. 모바일 환경에 최적화된 UI/UX 제공을 위한 디자인 개선

## 테스트 방법

1. 가게 상세 페이지 접속
2. 헤더의 하트 아이콘 클릭
   - 비로그인 상태: 로그인 모달 표시
   - 로그인 상태: 즐겨찾기 추가/삭제
3. 공유하기 버튼 클릭
   - 모바일: 네이티브 공유 시트 표시
   - 데스크톱: URL 복사
4. 스크롤하여 헤더 애니메이션 확인
5. 뒤로가기 버튼 클릭
   - 이전 페이지가 있는 경우: 이전 페이지로 이동
   - 없는 경우: 홈으로 이동

## 병합 전 체크리스트

- [x] 수정 내용에 오타나 컨벤션이 틀린 부분이 없는지 확인했나요?
- [x] 추가된 리뷰에 대해 모두 수정 및 재리뷰를 완료했나요?