### PR TITLE
회원가입 관련 버그 수정 및 주소 입력 버튼추가

### DIFF
--- a/src/components/shared/SignupModal.tsx
+++ b/src/components/shared/SignupModal.tsx
@@ -33,7 +33,7 @@ const signupFormSchema = z.object({
   signname: z
     .string()
     .min(1, '이메일을 입력해주세요.')
-    .max(255, '이메일은 255자 이내여야 합니다.')
+    .max(50, '이메일은 50자 이내여야 합니다.')
     .email('유효한 이메일 주소를 입력해주세요.'),
   password: z
     .string()
@@ -185,7 +185,7 @@ const SignupForm = () => {
             value={signnameValue}
             label="이메일 주소"
             placeholder="이메일 주소 입력"
-            maxLength={255}
+            maxLength={50}
             {...register('signname')}
             offOutline
             isInvalid={!!errors.signname && focusedField !== 'signname'}

--- a/src/components/shared/SignupModal.tsx
+++ b/src/components/shared/SignupModal.tsx
@@ -129,8 +129,10 @@ const SignupForm = () => {
         if (errorResponse.status === 400) {
           toast({
             title: '회원가입에 실패했습니다.',
-            description: (
+            description: errorResponse.message.includes('이미 가입된') ? (
               <span className="whitespace-pre-line">{'사용할 수 없는 이메일 주소입니다.'}</span>
+            ) : (
+              errorResponse.message
             ),
             variant: 'destructive',
           })

--- a/src/components/shared/SignupModal.tsx
+++ b/src/components/shared/SignupModal.tsx
@@ -29,7 +29,11 @@ const SignupModal = () => {
 export default SignupModal
 
 const signupFormSchema = z.object({
-  signname: z.string().min(1, '이메일을 입력해주세요.').email('유효한 이메일 주소를 입력해주세요.'),
+  signname: z
+    .string()
+    .min(1, '이메일을 입력해주세요.')
+    .max(255, '이메일은 255자 이내여야 합니다.')
+    .email('유효한 이메일 주소를 입력해주세요.'),
   password: z
     .string()
     .min(8, '비밀번호는 8자 이상이어야 합니다.')
@@ -146,6 +150,7 @@ const SignupForm = () => {
           value={signnameValue}
           label="이메일 주소"
           placeholder="이메일 주소 입력"
+          maxLength={255}
           {...register('signname')}
           offOutline
           isInvalid={!!errors.signname && focusedField !== 'signname'}

--- a/src/components/shared/SignupModal.tsx
+++ b/src/components/shared/SignupModal.tsx
@@ -144,105 +144,115 @@ const SignupForm = () => {
   }
 
   return (
-    <form onSubmit={onSubmit}>
-      <div className="mb-3">
-        <Input
-          value={signnameValue}
-          label="이메일 주소"
-          placeholder="이메일 주소 입력"
-          maxLength={255}
-          {...register('signname')}
-          offOutline
-          isInvalid={!!errors.signname && focusedField !== 'signname'}
-          onFocus={() => setFocusedField('signname')}
-          onReset={() => {
-            setValue('signname', '')
-          }}
-        />
-        {errors.signname && focusedField !== 'signname' && (
-          <div className="mt-1.5 text-left text-xs text-red-500">{errors.signname.message}</div>
-        )}
+    <form
+      onSubmit={onSubmit}
+      className="flex flex-col"
+      style={{
+        height: 'calc(100vh - 94px)',
+      }}
+    >
+      <div className="grow overflow-y-auto">
+        <div className="mb-3">
+          <Input
+            value={signnameValue}
+            label="이메일 주소"
+            placeholder="이메일 주소 입력"
+            maxLength={255}
+            {...register('signname')}
+            offOutline
+            isInvalid={!!errors.signname && focusedField !== 'signname'}
+            onFocus={() => setFocusedField('signname')}
+            onReset={() => {
+              setValue('signname', '')
+            }}
+          />
+          {errors.signname && focusedField !== 'signname' && (
+            <div className="mt-1.5 text-left text-xs text-red-500">{errors.signname.message}</div>
+          )}
+        </div>
+        <div className="mb-3">
+          <Input
+            value={passwordValue}
+            label="비밀번호"
+            type="password"
+            placeholder="영문, 숫자, 특수문자를 모두 포함한, 8자리 이상"
+            {...register('password')}
+            offOutline
+            isInvalid={!!errors.password && focusedField !== 'password'}
+            onFocus={() => {
+              setFocusedField('password')
+              trigger('signname')
+            }}
+          />
+          {errors.password && focusedField !== 'password' && (
+            <div className="mt-1.5 text-left text-xs text-red-500">{errors.password.message}</div>
+          )}
+        </div>
+        <div className="mb-3">
+          <Input
+            value={nicknameValue}
+            label="닉네임"
+            placeholder="영문 혹은 한글만 가능, 10자이내"
+            {...register('nickname')}
+            maxLength={10}
+            offOutline
+            isInvalid={!!errors.nickname && focusedField !== 'nickname'}
+            onFocus={() => {
+              setFocusedField('nickname')
+              trigger('signname')
+            }}
+            onReset={() => {
+              setValue('nickname', '')
+            }}
+          />
+          {errors.nickname && focusedField !== 'nickname' && (
+            <div className="mt-1.5 text-left text-xs text-red-500">{errors.nickname.message}</div>
+          )}
+        </div>
+        <div className="mb-3">
+          <Input
+            value={usernameValue}
+            label="이름"
+            placeholder="이름 입력"
+            {...register('username')}
+            maxLength={10}
+            offOutline
+            isInvalid={!!errors.username && focusedField !== 'username'}
+            onFocus={() => {
+              setFocusedField('username')
+              trigger('signname')
+            }}
+          />
+          {errors.username && focusedField !== 'username' && (
+            <div className="mt-1.5 text-left text-xs text-red-500">{errors.username.message}</div>
+          )}
+        </div>
+        <div className="mb-3">
+          <Input
+            value={phoneValue}
+            label="전화번호"
+            type="tel"
+            placeholder="전화번호 입력"
+            {...register('phone')}
+            onChange={handlePhoneChange}
+            maxLength={13}
+            offOutline
+            isInvalid={!!errors.phone && focusedField !== 'phone'}
+            onFocus={() => {
+              setFocusedField('phone')
+              trigger('signname')
+            }}
+          />
+          {errors.phone && focusedField !== 'phone' && (
+            <div className="mt-1.5 text-left text-xs text-red-500">{errors.phone.message}</div>
+          )}
+        </div>
       </div>
-      <div className="mb-3">
-        <Input
-          value={passwordValue}
-          label="비밀번호"
-          type="password"
-          placeholder="영문, 숫자, 특수문자를 모두 포함한, 8자리 이상"
-          {...register('password')}
-          offOutline
-          isInvalid={!!errors.password && focusedField !== 'password'}
-          onFocus={() => {
-            setFocusedField('password')
-            trigger('signname')
-          }}
-        />
-        {errors.password && focusedField !== 'password' && (
-          <div className="mt-1.5 text-left text-xs text-red-500">{errors.password.message}</div>
-        )}
+      <div className="bg-white py-2">
+        <Button className="disabled:bg-slate-400" type="submit" size="m" disabled={!isValid}>
+          가입하기
+        </Button>
       </div>
-      <div className="mb-3">
-        <Input
-          value={nicknameValue}
-          label="닉네임"
-          placeholder="영문 혹은 한글만 가능, 10자이내"
-          {...register('nickname')}
-          maxLength={10}
-          offOutline
-          isInvalid={!!errors.nickname && focusedField !== 'nickname'}
-          onFocus={() => {
-            setFocusedField('nickname')
-            trigger('signname')
-          }}
-          onReset={() => {
-            setValue('nickname', '')
-          }}
-        />
-        {errors.nickname && focusedField !== 'nickname' && (
-          <div className="mt-1.5 text-left text-xs text-red-500">{errors.nickname.message}</div>
-        )}
-      </div>
-      <div className="mb-3">
-        <Input
-          value={usernameValue}
-          label="이름"
-          placeholder="이름 입력"
-          {...register('username')}
-          maxLength={10}
-          offOutline
-          isInvalid={!!errors.username && focusedField !== 'username'}
-          onFocus={() => {
-            setFocusedField('username')
-            trigger('signname')
-          }}
-        />
-        {errors.username && focusedField !== 'username' && (
-          <div className="mt-1.5 text-left text-xs text-red-500">{errors.username.message}</div>
-        )}
-      </div>
-      <div className="mb-8">
-        <Input
-          value={phoneValue}
-          label="전화번호"
-          type="tel"
-          placeholder="전화번호 입력"
-          {...register('phone')}
-          onChange={handlePhoneChange}
-          maxLength={13}
-          offOutline
-          isInvalid={!!errors.phone && focusedField !== 'phone'}
-          onFocus={() => {
-            setFocusedField('phone')
-            trigger('signname')
-          }}
-        />
-        {errors.phone && focusedField !== 'phone' && (
-          <div className="mt-1.5 text-left text-xs text-red-500">{errors.phone.message}</div>
-        )}
-      </div>
-      <Button className="mb-2 disabled:bg-slate-400" type="submit" size="m" disabled={!isValid}>
-        가입하기
-      </Button>
     </form>
   )
 }


### PR DESCRIPTION
## 작업 내용

> 사진, 코드 등 리뷰어가 쉽게 이해할수 있게 상세히 리뷰어에 입장에서 작성해주요.
> 

- 회원가입 시 주소 입력 버튼 및 모달 추가
  - 주소 검색 빈 모달 추가
  - 주소 입력 필수값 처리

- 폼 유효성 검사 개선
  - 이메일 최대 길이 제한 (50자)
  - 주소 필드 유효성 검사 추가
  - 에러 메시지 개선 (서버 메시를 노출하도록 변경)

- 스크롤이 되지 않던 버그 수정


## 이러한 변경이 이루어지는 이유는 무엇인가요?

- 버그 수정
- 포스트맨으로 요청 시 회원가입이 가능하여 서버도 벨리데이션 추가 
- 구글의 글자수 제한을 참고
<img width="505" alt="image" src="https://github.com/user-attachments/assets/c47508b5-c569-42e5-b5e4-99fad1af3bf8" />


## 테스트 방법

> 변경사항에 대해 리뷰어가 테스트할 수 있는 가이드를 step by step으로 제공하세요.
> 
- [ ] 이메일 최대 길이 제한 동작 확인
- [ ] 주소 미입력 시 회원가입 불가
- [ ] 모바일 환경에서 레이아웃 정상 동작 확인


## 병합 전 체크리스트

- [ ]  수정 내용에 오타나 컨벤션이 틀린 부분이 없는지 확인했나요?
- [ ]  추가된 리뷰에 대해 모두 수정 및 재리뷰를 완료했나요?
