### PR TITLE
feat: 사용자 주문 취소 flow 추가

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,7 @@
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "prettier.requireConfig": true,
   "prettier.useEditorConfig": false,

--- a/.yarn/sdks/eslint/package.json
+++ b/.yarn/sdks/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint",
-  "version": "9.19.0-sdk",
+  "version": "9.21.0-sdk",
   "main": "./lib/api.js",
   "type": "commonjs",
   "bin": {

--- a/.yarn/sdks/prettier/package.json
+++ b/.yarn/sdks/prettier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier",
-  "version": "3.4.2-sdk",
+  "version": "3.5.2-sdk",
   "main": "./index.cjs",
   "type": "commonjs",
   "bin": "./bin/prettier.cjs"

--- a/src/api/useGetOrdersDetail.ts
+++ b/src/api/useGetOrdersDetail.ts
@@ -1,10 +1,12 @@
 import { api } from '@/lib/api'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 
-interface OrdersDetail {
+export type ORDER_STATUS_CODE = 'S1' | 'S2' | 'S3' | 'S4' | 'S5' | 'S6' // S1: 주문대기, S2: 주문접수, S3: 주문수락, S4: 주문거절, S5: 주문완료, S6: 주문취소
+
+export interface OrdersDetail {
   orderId: string
   status: {
-    code: string
+    code: ORDER_STATUS_CODE
     desc: string
   }
   orderTime: string

--- a/src/api/usePatchOrderCancel.ts
+++ b/src/api/usePatchOrderCancel.ts
@@ -1,0 +1,15 @@
+import { api } from '@/lib/api'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+const usePatchOrderCancel = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (orderId: string) => api.patch(`orders/${orderId}/cancel`, {}),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['ordersDetail'] })
+    },
+  })
+}
+
+export default usePatchOrderCancel

--- a/src/app/orders/detail/[id]/_components/OrderList.tsx
+++ b/src/app/orders/detail/[id]/_components/OrderList.tsx
@@ -1,63 +1,36 @@
+import { OrdersDetail } from '@/api/useGetOrdersDetail'
+import usePatchOrderCancel from '@/api/usePatchOrderCancel'
 import Chip from '@/components/Chip'
+import Confirm from '@/components/Confirm'
 import Separator from '@/components/Separator'
+import { modalStore } from '@/store/modal'
 import { v4 as uuidv4 } from 'uuid'
 
-interface OrderDataList {
-  ordersData: {
-    orderId: string
-    status: {
-      code: string
-      desc: string
-    }
-    orderTime: string
-    storeName: string
-    tel: string
-    roadAddress: string
-    jibunAddress: string
-    detailAddress: string
-    excludingSpoonAndFork: boolean
-    requestToRider: string | null
-    orderPrice: number
-    deliveryPrice: number
-    deliveryCompleteTime: string | null
-    paymentPrice: number
-    paymentId: number
-    paymentType: {
-      code: string
-      desc: string
-    }
-    type: {
-      code: string
-      desc: string
-    }
-    orderMenus: {
-      id: number
-      menuId: string
-      menuName: string
-      menuQuantity: number
-      menuPrice: number
-      totalPrice: number
-      orderMenuOptionGroups: {
-        id: number
-        orderMenuId: number
-        orderMenuOptionGroupName: string
-        orderMenuOptions: {
-          id: number
-          orderMenuOptionGroupId: number
-          menuOptionName: string
-          menuOptionPrice: number
-        }[]
-      }[]
-    }[]
-  }
+interface OrderListProps {
+  ordersData: OrdersDetail
 }
 
-const OrderList = ({ ordersData }: OrderDataList) => {
+const OrderList = ({ ordersData }: OrderListProps) => {
+  const { mutate: patchOrderCancel } = usePatchOrderCancel()
+  const { showModal } = modalStore()
+
+  const handleOrderCancel = () => {
+    showModal({
+      content: (
+        <Confirm
+          title="주문 취소"
+          message="주문을 취소하시겠습니까?"
+          onConfirmClick={() => patchOrderCancel(ordersData.orderId)}
+        />
+      ),
+    })
+  }
+
   return (
     <div className="flex flex-col px-mobile_safe">
       <div className="flex flex-row items-center justify-between pb-6">
         <div className="text-xl font-bold">{ordersData.storeName}</div>
-        <Chip text="주문 취소" />
+        {ordersData.status.code === 'S2' && <Chip text="주문 취소" onClick={handleOrderCancel} />}
       </div>
       <div className="flex flex-col gap-5">
         <div className="text-lg font-bold">주문정보</div>

--- a/src/app/orders/detail/[id]/_components/OrderStatus.tsx
+++ b/src/app/orders/detail/[id]/_components/OrderStatus.tsx
@@ -12,12 +12,14 @@ const OrderStatus: React.FC<OrderStatusProps> = ({ orderStatus }) => {
   const [title, setTitle] = useState('')
   const [subTitle, setSubTitle] = useState('')
   const [value, setValue] = useState(0)
+  const [isDisabledProgress, setIsDisabledProgress] = useState(false)
 
   useEffect(() => {
-    switch (status) {
+    switch (orderStatus) {
       case '주문거절':
         setTitle('주문이 거절되었습니다.')
         setSubTitle('다음에 다시 이용해 주세요')
+        setIsDisabledProgress(true)
         setValue(0)
         break
       case '주문접수':
@@ -40,13 +42,19 @@ const OrderStatus: React.FC<OrderStatusProps> = ({ orderStatus }) => {
         setSubTitle('맛있게 드시고 리뷰를 남겨주세요!')
         setValue(100)
         break
+      case '주문취소':
+        setTitle('주문을 취소했습니다')
+        setSubTitle('')
+        setValue(0)
+        setIsDisabledProgress(true)
+        break
       default:
         setTitle('')
         setSubTitle('')
         setValue(0)
         break
     }
-  }, [status])
+  }, [orderStatus])
 
   return (
     <div className="px-mobile_safe">
@@ -55,20 +63,23 @@ const OrderStatus: React.FC<OrderStatusProps> = ({ orderStatus }) => {
           <div className="text-xl font-bold">{title}</div>
           <div className="text-sm text-gray-400">{subTitle}</div>
         </div>
-        <div className="flex flex-col gap-2">
-          <Progress value={value} />
-          <div className="flex flex-row justify-evenly text-sm">
-            <div className={status === '주문수락' ? 'text-primary' : 'text-gray-400'}>
-              주문 수락
-            </div>
-            <div className={status === '배달진행중' ? 'text-primary' : 'text-gray-400'}>
-              배달 진행중
-            </div>
-            <div className={status === '배달완료' ? 'text-primary' : 'text-gray-400'}>
-              배달 완료
+        {!isDisabledProgress && (
+          <div className="flex flex-col gap-2">
+            <Progress value={value} />
+
+            <div className="flex flex-row justify-evenly text-sm">
+              <div className={status === '주문수락' ? 'text-primary' : 'text-gray-400'}>
+                주문 수락
+              </div>
+              <div className={status === '배달진행중' ? 'text-primary' : 'text-gray-400'}>
+                배달 진행중
+              </div>
+              <div className={status === '배달완료' ? 'text-primary' : 'text-gray-400'}>
+                배달 완료
+              </div>
             </div>
           </div>
-        </div>
+        )}
       </div>
     </div>
   )

--- a/src/app/orders/detail/[id]/page.tsx
+++ b/src/app/orders/detail/[id]/page.tsx
@@ -1,10 +1,10 @@
 'use client'
 
-import Separator from '@/components/Separator'
-import OrderStatus from '@/app/orders/detail/[id]/_components/OrderStatus'
-import OrderList from '@/app/orders/detail/[id]/_components/OrderList'
-import { usePathname } from 'next/navigation'
 import useGetOrdersDetail from '@/api/useGetOrdersDetail'
+import OrderList from '@/app/orders/detail/[id]/_components/OrderList'
+import OrderStatus from '@/app/orders/detail/[id]/_components/OrderStatus'
+import Separator from '@/components/Separator'
+import { usePathname } from 'next/navigation'
 import { useEffect, useState } from 'react'
 
 const OrderDetailPage = () => {
@@ -17,9 +17,12 @@ const OrderDetailPage = () => {
 
   useEffect(() => {
     if (ordersDetail) {
+      console.log(ordersDetail.status.desc)
       setStatus(ordersDetail.status.desc)
     }
   }, [ordersDetail])
+
+  if (!ordersDetail) return <div>주문 상세 정보를 불러오는 중입니다.</div>
 
   return (
     <div className="flex flex-col gap-5">

--- a/src/components/Confirm.tsx
+++ b/src/components/Confirm.tsx
@@ -22,6 +22,7 @@ const Confirm = ({
 
   const handleConfirmClick = () => {
     hideModal()
+    console.log({onConfirmClick})
     onConfirmClick()
   }
 


### PR DESCRIPTION
## 작업 내용

주문 취소 기능을 구현했습니다.

### API 변경사항
- `usePatchOrderCancel.ts` 파일 추가: 주문 취소 API 호출을 위한 커스텀 훅 구현
- `useGetOrdersDetail.ts`에 주문 상태 코드 타입 추가 (`ORDER_STATUS_CODE`)

### UI 변경사항
1. OrderList 컴포넌트
   - 주문 상태가 'S2'(주문접수) 일 때만 주문 취소 버튼 표시
   - 주문 취소 버튼 클릭 시 확인 모달 표시

2. OrderStatus 컴포넌트
   - 주문 취소 상태 추가
   - 주문 거절/취소 상태일 때 진행바 비활성화

### 기타 변경사항
- VS Code 설정 및 yarn SDK 버전 업데이트
  - eslint: 9.19.0 → 9.21.0
  - prettier: 3.4.2 → 3.5.2

## 이러한 변경이 이루어지는 이유는 무엇인가요?

사용자가 주문 접수 상태에서 주문을 취소할 수 있는 기능이 필요하여 구현하였습니다. 주문 취소 기능을 통해 사용자의 편의성을 향상시키고, 불필요한 주문 진행을 방지할 수 있습니다.

## 테스트 방법

1. 주문 상세 페이지에서 주문 상태가 '주문접수'인 주문 확인
2. 주문 취소 버튼 클릭
3. 확인 모달에서 '확인' 버튼 클릭
4. 주문 상태가 '주문취소'로 변경되고 진행바가 사라지는지 확인

## 병합 전 체크리스트

- [ ] 수정 내용에 오타나 컨벤션이 틀린 부분이 없는지 확인했나요?
- [ ] 추가된 리뷰에 대해 모두 수정 및 재리뷰를 완료했나요?