### PR TITLE
회원가입 시 주소 입력

### DIFF
--- a/src/api/usePostLogout.ts
+++ b/src/api/usePostLogout.ts
@@ -22,6 +22,7 @@ const usePostLogout = () => {
       queryClient.removeQueries({ queryKey: ['member'] })
       queryClient.removeQueries({ queryKey: ['favorites'] })
       queryClient.removeQueries({ queryKey: ['carts'] })
+      queryClient.removeQueries({ queryKey: ['address'] })
     },
     retry: 0,
   })

--- a/src/app/mypage/address/_components/AddressOption.tsx
+++ b/src/app/mypage/address/_components/AddressOption.tsx
@@ -20,6 +20,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { useState } from 'react'
 import DaumPostcode from 'react-daum-postcode'
 import AddressDetail, { AddressData } from '../detail/_components/AddressDetail'
+import { SignupData } from '@/models/auth'
 
 const AddressOption = () => {
   const [word, setWord] = useState('')
@@ -310,16 +311,26 @@ const AddressOption = () => {
     )
 }
 
-const AddressDetailModal = ({
+export const AddressDetailModal = ({
   type,
   userAddress,
   addressData,
+  onSaveInSignup,
 }: {
   type?: AddressType
   userAddress?: AddressResponseData
   addressData?: AddressData
+  onSaveInSignup?: (addressData: SignupData['address']) => void
 }) => {
   const { hideModal } = modalStore()
+
+  const handleClose = () => {
+    hideModal()
+    if (onSaveInSignup) {
+      // 회원가입 시 주소 검색 모달 추가로 닫기
+      hideModal()
+    }
+  }
 
   return (
     <div className="w-full max-w-[min(480px,100dvw)] bg-white">
@@ -327,10 +338,15 @@ const AddressDetailModal = ({
         <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-lg font-bold">
           주소 등록
         </div>
-        <Icon name="X" size={24} onClick={hideModal} className="stroke-2" />
+        <Icon name="X" size={24} onClick={handleClose} className="stroke-2" />
       </div>
       <div className="h-[calc(100dvh-64px)] overflow-y-auto">
-        <AddressDetail type={type} userAddress={userAddress} defaultAddressData={addressData} />
+        <AddressDetail
+          type={type}
+          userAddress={userAddress}
+          defaultAddressData={addressData}
+          onSaveInSignup={onSaveInSignup}
+        />
       </div>
     </div>
   )

--- a/src/app/mypage/address/_components/AddressOption.tsx
+++ b/src/app/mypage/address/_components/AddressOption.tsx
@@ -14,13 +14,13 @@ import Separator from '@/components/Separator'
 import LoginButtonSection from '@/components/shared/LoginButtonSection'
 import { useToast } from '@/hooks/useToast'
 import { cn } from '@/lib/utils'
+import { SignupData } from '@/models/auth'
 import { modalStore } from '@/store/modal'
 import memberStore from '@/store/user'
 import { useQueryClient } from '@tanstack/react-query'
 import { useState } from 'react'
 import DaumPostcode from 'react-daum-postcode'
 import AddressDetail, { AddressData } from '../detail/_components/AddressDetail'
-import { SignupData } from '@/models/auth'
 
 const AddressOption = () => {
   const [word, setWord] = useState('')
@@ -326,10 +326,6 @@ export const AddressDetailModal = ({
 
   const handleClose = () => {
     hideModal()
-    if (onSaveInSignup) {
-      // 회원가입 시 주소 검색 모달 추가로 닫기
-      hideModal()
-    }
   }
 
   return (

--- a/src/app/mypage/address/detail/_components/AddressDetail.tsx
+++ b/src/app/mypage/address/detail/_components/AddressDetail.tsx
@@ -7,6 +7,7 @@ import { useGeoLocationStore } from '@/store/geoLocation'
 import { useState } from 'react'
 import { useKakaoLoader } from 'react-kakao-maps-sdk'
 import MapInfo from './MapInfo'
+import { SignupData } from '@/models/auth'
 
 export interface AddressData {
   type: AddressType | undefined
@@ -24,10 +25,12 @@ const AddressDetail = ({
   type = AddressType.HOME,
   userAddress,
   defaultAddressData,
+  onSaveInSignup,
 }: {
   type?: AddressType
   userAddress?: AddressResponseData
   defaultAddressData?: AddressData
+  onSaveInSignup?: (addressData: SignupData['address']) => void
 }) => {
   const [loading] = useKakaoLoader({
     appkey: process.env.NEXT_PUBLIC_KAKAO_APP_KEY!,
@@ -66,6 +69,7 @@ const AddressDetail = ({
         addressData={addressData}
         onAddressChange={handleAddressChange}
         userAddress={userAddress}
+        onSaveInSignup={onSaveInSignup}
       />
     </div>
   )

--- a/src/app/mypage/address/detail/_components/MapInfo.tsx
+++ b/src/app/mypage/address/detail/_components/MapInfo.tsx
@@ -13,15 +13,18 @@ import { modalStore } from '@/store/modal'
 import { useQueryClient } from '@tanstack/react-query'
 import { useEffect, useState } from 'react'
 import { AddressData } from './AddressDetail'
+import { SignupData } from '@/models/auth'
 
 const MapInfo = ({
   addressData,
   onAddressChange,
   userAddress,
+  onSaveInSignup,
 }: {
   addressData: AddressData
   onAddressChange: (data: AddressData) => void
   userAddress?: AddressResponseData
+  onSaveInSignup?: (addressData: SignupData['address']) => void
 }) => {
   const queryClient = useQueryClient()
   const { toast } = useToast()
@@ -68,6 +71,19 @@ const MapInfo = ({
         })
         return
       }
+    }
+
+    if (onSaveInSignup) {
+      onSaveInSignup({
+        memberAddressType: addressData.type as AddressType,
+        roadAddress: addressData.roadAddr || addressData.address,
+        jibunAddress: addressData.address,
+        detailAddress: addressDetail,
+        alias: addressData.type === AddressType.OTHERS ? alias : '',
+        latitude: addressData.coords.lat,
+        longitude: addressData.coords.lng,
+      })
+      return
     }
 
     const _address: Address = {

--- a/src/app/mypage/address/detail/_components/MapInfo.tsx
+++ b/src/app/mypage/address/detail/_components/MapInfo.tsx
@@ -9,11 +9,11 @@ import Input from '@/components/Input'
 import { Button } from '@/components/button'
 import { useToast } from '@/hooks/useToast'
 import { cn } from '@/lib/utils'
+import { SignupData } from '@/models/auth'
 import { modalStore } from '@/store/modal'
 import { useQueryClient } from '@tanstack/react-query'
 import { useEffect, useState } from 'react'
 import { AddressData } from './AddressDetail'
-import { SignupData } from '@/models/auth'
 
 const MapInfo = ({
   addressData,

--- a/src/components/shared/SignupModal.tsx
+++ b/src/components/shared/SignupModal.tsx
@@ -376,7 +376,7 @@ const AddressModal = ({
         <div className="mb-2 flex justify-end">
           <Icon name="X" size={24} onClick={handleClose} className="stroke-2" />
         </div>
-        <DaumPostcode onComplete={handleComplete} />
+        <DaumPostcode onComplete={handleComplete} autoClose={false} />
       </div>
     </div>
   )

--- a/src/components/shared/SignupModal.tsx
+++ b/src/components/shared/SignupModal.tsx
@@ -292,26 +292,26 @@ const SignupForm = () => {
           >
             주소
           </label>
-          <Button
-            id="address"
-            className="w-full"
-            variant="grayFit"
-            size="m"
-            type="button"
-            onClick={handleAddressClick}
-          >
-            주소 찾기
-          </Button>
-
-          {addressValue?.roadAddress ? (
-            <div className="mt-2 text-left text-lg font-semibold">
-              {addressValue?.roadAddress + ' ' + addressValue?.detailAddress}
-            </div>
-          ) : (
-            isClickedAddressButton && (
+          <div id="address">
+            <Button
+              className="flex w-full truncate text-wrap"
+              variant="grayFit"
+              size="m"
+              type="button"
+              onClick={handleAddressClick}
+            >
+              {addressValue?.roadAddress ? (
+                <span className="overflow-hidden text-ellipsis">
+                  {addressValue?.roadAddress + ' ' + addressValue?.detailAddress}
+                </span>
+              ) : (
+                '주소 찾기'
+              )}
+            </Button>
+            {!addressValue?.roadAddress && isClickedAddressButton && (
               <div className="mt-1.5 text-left text-xs text-red-500">주소를 입력해주세요.</div>
-            )
-          )}
+            )}
+          </div>
         </div>
       </div>
       <div className="bg-white py-2">

--- a/src/components/shared/SignupModal.tsx
+++ b/src/components/shared/SignupModal.tsx
@@ -350,8 +350,6 @@ const AddressModal = ({
               onSaveInSignup={onSaveInSignup}
             />
           ),
-          useAnimation: true,
-          useDimmedClickClose: true,
         })
       },
       onError: (error) => {

--- a/src/components/shared/SignupModal.tsx
+++ b/src/components/shared/SignupModal.tsx
@@ -299,7 +299,7 @@ const SignupForm = () => {
               onClick={handleAddressClick}
             >
               {addressValue?.roadAddress ? (
-                <span className="overflow-hidden text-ellipsis">
+                <span className="line-clamp-2 text-left text-sm font-medium">
                   {addressValue?.roadAddress + ' ' + addressValue?.detailAddress}
                 </span>
               ) : (

--- a/src/components/shared/SignupModal.tsx
+++ b/src/components/shared/SignupModal.tsx
@@ -164,7 +164,9 @@ const SignupForm = () => {
   }
 
   const handleChangeAddress = (addressData: SignupData['address']) => {
-    setValue('address', addressData)
+    setValue('address', addressData, {
+      shouldValidate: true, // 주소 입력 시 유효성 검사 실행
+    })
     hideModal() // 주소 찾기 디테일 모달 닫기
     hideModal() // 주소 찾기 모달 닫기
   }

--- a/src/components/shared/SignupModal.tsx
+++ b/src/components/shared/SignupModal.tsx
@@ -59,6 +59,7 @@ const signupFormSchema = z.object({
     .regex(/^[a-zA-Z가-힣]+$/, '이름은 영문, 한글만 가능합니다.'),
   phone: z
     .string()
+    .min(1, '전화번호를 입력해주세요.')
     .min(10, '전화번호는 8자 이상이어야 합니다.')
     .max(13, '전화번호는 11자 이내여야 합니다.'),
   address: z.object({
@@ -74,7 +75,6 @@ const signupFormSchema = z.object({
 
 const SignupForm = () => {
   const { showModal, hideModal } = modalStore()
-  const phoneInputRef = useRef<HTMLInputElement>(null)
   const { mutate: signup } = usePostSignup()
   const { toast } = useToast()
   const {
@@ -167,7 +167,6 @@ const SignupForm = () => {
     setValue('address', addressData)
     hideModal() // 주소 찾기 디테일 모달 닫기
     hideModal() // 주소 찾기 모달 닫기
-    phoneInputRef.current?.focus() // 전화번호 입력 필드로 포커스 이동하여 가입하기 버튼 활성화
   }
 
   const handleAddressClick = () => {
@@ -279,7 +278,6 @@ const SignupForm = () => {
               setFocusedField('phone')
               trigger('signname')
             }}
-            ref={phoneInputRef}
           />
           {errors.phone && focusedField !== 'phone' && (
             <div className="mt-1.5 text-left text-xs text-red-500">{errors.phone.message}</div>


### PR DESCRIPTION
## 작업 내용

> 사진, 코드 등 리뷰어가 쉽게 이해할수 있게 상세히 리뷰어에 입장에서 작성해주요.
> 

회원가입 주소 입력 부분 구현
   -  AddressDetailModal 컴포넌트를 export하여 재사용 가능하도록 수정
   - 회원가입 시 주소 저장을 위한 onSaveInSignup prop 추가



내용

## 이러한 변경이 이루어지는 이유는 무엇인가요?

내용 

## 테스트 방법

> 변경사항에 대해 리뷰어가 테스트할 수 있는 가이드를 step by step으로 제공하세요.
> 
[ ] 회원가입 시 주소 입력이 가능한지 확인
[ ] 가입 후 주소 관리에서 주소가 정상 반영됐는지 확인  

## 병합 전 체크리스트

- [ ]  수정 내용에 오타나 컨벤션이 틀린 부분이 없는지 확인했나요?
- [ ]  추가된 리뷰에 대해 모두 수정 및 재리뷰를 완료했나요?
